### PR TITLE
feat: recolor a paleta HLCS (paso 2) — rojo más cálido + tokens de ámbar

### DIFF
--- a/src/modules/portfolio/components/InputGlitch.astro
+++ b/src/modules/portfolio/components/InputGlitch.astro
@@ -80,7 +80,7 @@ const { labelName, labelFor, dataText } = label || {}
     font-family: inherit;
     font-size: 1.1rem;
     color: var(--text-color);
-    caret-color: var(--primary-color);
+    caret-color: var(--amber-glow);
     z-index: 10;
     transition:
       background 0.3s ease,

--- a/src/modules/portfolio/components/TextareaGlitch.astro
+++ b/src/modules/portfolio/components/TextareaGlitch.astro
@@ -73,7 +73,7 @@ const { labelName, labelFor, dataText } = label
     font-family: inherit;
     font-size: 1.1rem;
     color: var(--text-color);
-    caret-color: var(--primary-color);
+    caret-color: var(--amber-glow);
     z-index: 10;
     transition:
       background 0.3s ease,

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -67,16 +67,23 @@ const { title, image, summary, url, lang, links } = Astro.props;
 	:root {
 		color-scheme: light dark;
 		
+		/* CIAN · datos / nominal */
 		--cyan-core: #E4FBFB;
 		--cyan-glow: #00F7FF;
 		--cyan-accent: #00B8BF;
 		--cyan-muted: #1F4345;
 
-		--red-core: #FBE4E4;
-		--red-glow: #FF0800;
+		/* ROJO · identidad / alerta */
+		--red-core: #FFE3DE;
+		--red-glow: #FF2D0F;
 		--red-accent: #BF0600;
-		--red-muted: #893f3b;
+		--red-muted: #893F3B;
 
+		/* ÁMBAR · señal (aplicación real —cursor, boot, warnings— en pasos posteriores) */
+		--amber-glow: #FFB000;
+		--amber-core: #FFE9C2;
+
+		/* FONDO · rampa cálida */
 		--bg-field: #080404;
 		--bg-base: #151111;
 		--bg-raised: #1F1616;


### PR DESCRIPTION
Cambio SOLO de valores de color (nada de layout, tipografía, roles ni estructura). Gracias a la tokenización del paso 1, toca esencialmente el :root.

:root (antes → después):
- --red-glow:   #FF0800 → #FF2D0F   (un pelo más cálido)
- --red-core:   #FBE4E4 → #FFE3DE   (alineado, diferencia mínima)
- --red-muted:  #893f3b → #893F3B   (solo mayúsculas, mismo color)
- --amber-glow: #FFB000             (NUEVO)
- --amber-core: #FFE9C2             (NUEVO)
- cian y rampa de fondo (#080404/#151111/#1F1616): sin cambios (ya coincidían)

Primer y único uso del ámbar: caret-color de los inputs → var(--amber-glow).

Verificado: build verde (8 páginas). Diff de colores del dist vs paso 1 = exactamente +{ff2d0f, ffe3de, ffb000, ffe9c2} y -{ff0800, fbe4e4}; nada más. Sin hardcode residual (los valores viejos solo vivían en :root).