### PR TITLE
feat(typography): sistema tipográfico de 3 voces tokenizado

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "portafolio",
-  "version": "0.0.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portafolio",
-      "version": "0.0.1",
+      "version": "1.8.0",
       "dependencies": {
         "@fontsource-variable/orbitron": "5.0.18",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/vt323": "^5.2.7",
         "animejs": "3.2.2",
         "astro": "^5.16.4",
         "hotkeypad": "^1.0.2"
@@ -807,6 +809,24 @@
       "resolved": "https://registry.npmjs.org/@fontsource-variable/orbitron/-/orbitron-5.0.18.tgz",
       "integrity": "sha512-RFZfk6drK2liLBHHfgBBSU9CiVwqMZ9/NQxMY5K4fZYJ3A4cIiILSREu8Pio5CMdOqsKS9N3pJpy79xRGLl4Bg==",
       "license": "OFL-1.1"
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/vt323": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/vt323/-/vt323-5.2.7.tgz",
+      "integrity": "sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@fontsource-variable/orbitron": "5.0.18",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/vt323": "^5.2.7",
     "animejs": "3.2.2",
     "astro": "^5.16.4",
     "hotkeypad": "^1.0.2"

--- a/src/modules/portfolio/components/About.astro
+++ b/src/modules/portfolio/components/About.astro
@@ -155,6 +155,8 @@ const { lang, summary, name, image } = Astro.props;
     bottom: 5px;
     left: 50%;
     transform: translateX(-50%);
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
   }
 
   .pixel {

--- a/src/modules/portfolio/components/ButtonGlitch.astro
+++ b/src/modules/portfolio/components/ButtonGlitch.astro
@@ -71,9 +71,9 @@ const buttonColors = color === "secondary"
     background-color: transparent;
     color: var(--primary-color);
     font-size: 1rem;
-    font-weight: 700;
+    font-weight: 600;
     font-family: inherit;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.08em;
     cursor: pointer;
     border-radius: 10px;
     position: relative;

--- a/src/modules/portfolio/components/Contact.astro
+++ b/src/modules/portfolio/components/Contact.astro
@@ -163,6 +163,9 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
 
 <style>
   header {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-subtitle);
     background-color: var(--red-glow);
     width: 60%;
     color: var(--bg-field);
@@ -184,11 +187,19 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
   article p {
     color: var(--red-accent);
   }
+  article > p {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    line-height: 1.2;
+  }
   .network {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-meta);
     text-transform: uppercase;
   }
   .username {
-    font-size: 0.85rem;
+    font-size: var(--fs-meta);
   }
   .contact-info {
     display: flex;

--- a/src/modules/portfolio/components/ExperienceCard.astro
+++ b/src/modules/portfolio/components/ExperienceCard.astro
@@ -98,6 +98,9 @@ const { lang, name, position, url, startDate, endDate, summary, highlights, team
     background-color: var(--bg-base);
   }
   h2 {
+    font-family: var(--font-display);
+    font-size: var(--fs-subtitle);
+    font-weight: var(--fw-title);
     color: var(--card-heading);
     transition: color 0.3s ease;
   }
@@ -105,6 +108,11 @@ const { lang, name, position, url, startDate, endDate, summary, highlights, team
     color: var(--red-accent);
     text-decoration: none;
     transition: color 0.3s ease;
+  }
+  time {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    line-height: 1;
   }
   article:hover h2, article:hover .company-wrapper, article:hover .company-wrapper a {
     color: var(--cyan-accent);
@@ -158,16 +166,24 @@ const { lang, name, position, url, startDate, endDate, summary, highlights, team
     padding-left: 0.8rem;
   }
   h3 {
+    font-family: var(--font-terminal);
     color: var(--red-accent);
-    font-weight: lighter;
-    font-size: large;
+    font-weight: 400;
+    font-size: var(--fs-lead);
+    line-height: 1.1;
     transition: color 0.3s ease;
   }
   article:hover h3 {
     color: var(--cyan-accent);
     transition: color 0.3s ease;
   }
+  h4 {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-lead);
+  }
   h6 {
+    font-size: var(--fs-meta);
     color: var(--red-muted);
     transition: color 0.3s ease;
   }

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -68,6 +68,8 @@ const { lang, name, label } = Astro.props;
 		margin-top: -10rem;
 	}
 	h1 {
+		font-family: var(--font-display);
+		font-weight: var(--fw-display);
 		font-size: clamp(1.5em, 8vw, 2.5em);
 		color: var(--red-glow);
 		text-shadow: 0 0 15px var(--red-glow);

--- a/src/modules/portfolio/components/ProjectsCard.astro
+++ b/src/modules/portfolio/components/ProjectsCard.astro
@@ -93,6 +93,7 @@ const { id, name, image, summary, description, technologies, url, repo } = Astro
   article {
     max-width: 500px;
     width: 100%;
+    min-width: 0;
     background: var(--bg-base);
     border: 2px solid var(--red-muted);
     border-radius: 5px;
@@ -109,6 +110,14 @@ const { id, name, image, summary, description, technologies, url, repo } = Astro
     align-items: center;
     gap: 0.3rem;
     color: var(--red-muted);
+  }
+  header h5 {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-meta);
+    letter-spacing: 0.05em;
+    overflow-wrap: anywhere;
+    min-width: 0;
   }
   figure {
     width: 100%;
@@ -129,6 +138,9 @@ const { id, name, image, summary, description, technologies, url, repo } = Astro
     gap: 0.8rem;
   }
   .content h4 {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-subtitle);
     color: var(--red-glow);
   }
   .content p {

--- a/src/modules/portfolio/components/ProjectsDetail.astro
+++ b/src/modules/portfolio/components/ProjectsDetail.astro
@@ -141,6 +141,13 @@ const { lang, projects } = Astro.props;
     border-radius: 6px 6px 0 0;
     z-index: 1;
   }
+  header h3 {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-subtitle);
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
   article {
     width: 100%;
     background-color: var(--bg-base);
@@ -165,6 +172,9 @@ const { lang, projects } = Astro.props;
     gap: 0.5rem;
   }
   h4 {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    line-height: 1.1;
     color: var(--red-accent);
   }
   .highlights {

--- a/src/modules/portfolio/components/Section.astro
+++ b/src/modules/portfolio/components/Section.astro
@@ -53,12 +53,17 @@ const { id, title, subTittle, styles } = Astro.props;
   }
 
   h1 {
+    font-family: var(--font-display);
+    font-size: var(--fs-title);
+    font-weight: var(--fw-title);
     color: var(--red-glow);
     text-shadow: 0 0 15px var(--red-glow);
     text-transform: uppercase;
   }
   p {
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    line-height: 1.2;
     text-transform: uppercase;
     color: var(--red-muted);
   }

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -1,5 +1,10 @@
 ---
 import '@fontsource-variable/orbitron';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-mono/400-italic.css';
+import '@fontsource/vt323/400.css';
 
 import NavBar from './components/NavBar.astro';
 import Footer from './components/Footer.astro';
@@ -92,10 +97,27 @@ const { title, image, summary, url, lang, links } = Astro.props;
 		--cream: #fff7ed;
 		--glitch-label-bg: #212121;
 		--white-transparent: rgba(255, 255, 255, 0);
+
+		/* TIPOGRAFÍA · 3 voces */
+		--font-display: 'Orbitron Variable', sans-serif;   /* nombre, headers, etiquetas de panel */
+		--font-body: 'IBM Plex Mono', ui-monospace, 'Courier New', monospace; /* lectura, UI, botones */
+		--font-terminal: 'VT323', 'Courier New', monospace; /* sabor terminal: prompts, timestamps */
+
+		/* TIPOGRAFÍA · escala */
+		--fs-display: clamp(2.25rem, 6vw, 3rem);   /* ~48 · display / nombre */
+		--fs-title: 1.75rem;                        /* ~28 · título de sección */
+		--fs-subtitle: 1.25rem;                     /* ~20 · título de tarjeta / panel */
+		--fs-lead: 1.125rem;                        /* ~18 · lead / prompts */
+		--fs-body: 0.9375rem;                       /* ~15 · cuerpo */
+		--fs-meta: 0.75rem;                         /* ~12 · meta */
+
+		--fw-display: 600;
+		--fw-title: 600;
+		--fw-body: 400;
 	}
 
 	html {
-		font-family: 'Orbitron Variable', sans-serif;
+		font-family: var(--font-display);
 		scroll-behavior: smooth;
 	}
 
@@ -113,6 +135,12 @@ const { title, image, summary, url, lang, links } = Astro.props;
 	body {
 		background-color: color-mix(in srgb, var(--bg-base) 100%, transparent);
 		color: var(--red-core);
+		font-family: var(--font-body);
+		font-size: var(--fs-body);
+		font-weight: var(--fw-body);
+		line-height: 1.5;
+		/* La fuente monoespaciada es más ancha: evita desbordes de texto */
+		overflow-wrap: break-word;
   }
 
 	* {

--- a/src/modules/portfolio/layout/components/Footer.astro
+++ b/src/modules/portfolio/layout/components/Footer.astro
@@ -76,6 +76,9 @@ const { lang } = Astro.props;
 		gap: 1em;
 		margin: 0.5em;
 	}
+	figure p {
+		font-family: var(--font-display);
+	}
 	svg {
 		width: 25px;
 		height: 25px;

--- a/src/modules/portfolio/layout/components/NavBar.astro
+++ b/src/modules/portfolio/layout/components/NavBar.astro
@@ -169,13 +169,14 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 		transition: 0.3s;
 	}
 	h1 {
+		font-family: var(--font-display);
 		color: var(--red-core);
 		padding: 0.2em 0.4em;
 		border-radius: 5px;
 		border: 1px solid var(--red-core);
 		text-align: center;
 		font-size: 25px;
-		font-weight: 400;
+		font-weight: var(--fw-title);
 		transition: 0.3s;
 	}
 	.name-off {

--- a/src/shared/components/MobileWarning.astro
+++ b/src/shared/components/MobileWarning.astro
@@ -92,6 +92,11 @@ const message = messages[lang as keyof typeof messages] || messages.en;
     border-radius: 6px 6px 0 0;
     z-index: 1;
   }
+  header h3 {
+    font-family: var(--font-display);
+    font-weight: var(--fw-title);
+    font-size: var(--fs-subtitle);
+  }
   article {
     width: 70%;
     background-color: var(--bg-base);


### PR DESCRIPTION
## Paso 3 — Tipografía

Sistema tipográfico de **3 voces + una escala**, tokenizado como variables CSS. El cambio visible intencional: el **cuerpo** pasa de Orbitron a **IBM Plex Mono** (más legible). Alcance limitado a tipografía — sin tocar color, glow, CRT, layout ni la lógica del hero.

### Qué cambia

**Fuentes (auto-hospedadas con `@fontsource`, `font-display: swap`)**
- **IBM Plex Mono** — 400, 500, 600 + itálica 400 (solo los pesos que se usan).
- **VT323** — 400.
- **Orbitron** se mantiene (carga variable ya existente).

**Familias tokenizadas en `:root`**
- `--font-display` → Orbitron
- `--font-body` → IBM Plex Mono (fuente base del `body`)
- `--font-terminal` → VT323

**Escala tipográfica** (tokens `--fs-*`, aplicados a headings/cuerpo/meta sin rediseñar spacing)
- display ~48 · título ~28 · subtítulo ~20 · lead ~18 · **cuerpo 15px** · meta 12px

**Roles asignados**
- **Display (Orbitron):** nombre (hero, nav, footer), headers de sección y etiquetas de panel (títulos de tarjeta, cabeceras `Contact_interface`, `Expense_Control_Platform`, etc.).
- **Body (IBM Plex Mono):** todo el texto de lectura, datos, UI y botones — el cambio grande.
- **Terminal (VT323):** solo el sabor terminal que ya existía — líneas con prompt `>`, etiquetas tipo `REGISTRO_PERSONAL` / `MISSION_BRIEF`, y timestamps. No se fuerza en texto normal.

**Riesgo de monoespaciada — overflow**
- IBM Plex Mono es más ancha. Los nombres de proyecto unidos por guiones bajos (`Plataforma_de_Control_...`) eran tokens no-rompibles y desbordaban las tarjetas en móvil. Corregido con `overflow-wrap` + `min-width: 0` en esas etiquetas y una regla de seguridad global en `body`. Sin rediseñar el layout.

### Verificación
- `npm run build` pasa sin errores (8 páginas).
- Fuentes cargan bien (woff2 latin/latin-ext bundleados, sin FOUT notorio).
- Roles confirmados en runtime: `body` = IBM Plex Mono @ 15px; nombre/headers = Orbitron; subtítulos de sección = VT323.
- **Sin desbordes horizontales** en ES y EN, en escritorio (1280) y móvil (375) — verificado con Chromium (`scrollWidth == clientWidth`, cero elementos fuera de viewport), incluida la vista de detalle de proyecto.
- El módulo CV (fuente propia) no se toca.

> Nota: los mensajes de consola preexistentes (404 de favicon con doble `/`, `ERR_TUNNEL` de imágenes externas/web3forms bloqueadas por el proxy del sandbox, y un `classList` en el script del NavBar) ya existían en `dev` antes de este cambio y son ajenos a tipografía, por lo que quedan fuera de alcance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZJ67Rctv6kE1M8exvQB2p)_