### PR TITLE
feat(typography): sistema tipográfico de 3 voces tokenizado (paso 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "portafolio",
-  "version": "0.0.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portafolio",
-      "version": "0.0.1",
+      "version": "1.8.0",
       "dependencies": {
         "@fontsource-variable/orbitron": "5.0.18",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/vt323": "^5.2.7",
         "animejs": "3.2.2",
         "astro": "^5.16.4",
         "hotkeypad": "^1.0.2"
@@ -807,6 +809,24 @@
       "resolved": "https://registry.npmjs.org/@fontsource-variable/orbitron/-/orbitron-5.0.18.tgz",
       "integrity": "sha512-RFZfk6drK2liLBHHfgBBSU9CiVwqMZ9/NQxMY5K4fZYJ3A4cIiILSREu8Pio5CMdOqsKS9N3pJpy79xRGLl4Bg==",
       "license": "OFL-1.1"
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/vt323": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/vt323/-/vt323-5.2.7.tgz",
+      "integrity": "sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@fontsource-variable/orbitron": "5.0.18",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/vt323": "^5.2.7",
     "animejs": "3.2.2",
     "astro": "^5.16.4",
     "hotkeypad": "^1.0.2"

--- a/src/modules/portfolio/components/ButtonGlitch.astro
+++ b/src/modules/portfolio/components/ButtonGlitch.astro
@@ -72,8 +72,8 @@ const buttonColors = color === "secondary"
     color: var(--primary-color);
     font-size: 1rem;
     font-weight: 700;
-    font-family: inherit;
-    letter-spacing: 0.2em;
+    font-family: var(--font-display);
+    letter-spacing: 0.12em;
     cursor: pointer;
     border-radius: 10px;
     position: relative;

--- a/src/modules/portfolio/components/Contact.astro
+++ b/src/modules/portfolio/components/Contact.astro
@@ -163,6 +163,8 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
 
 <style>
   header {
+    font-family: var(--font-display);
+    letter-spacing: 0.08em;
     background-color: var(--red-glow);
     width: 60%;
     color: var(--bg-field);
@@ -180,6 +182,11 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
     gap: 2rem;
     border-radius: 0 0 6px 6px;
     z-index: 1;
+  }
+  article > p {
+    font-family: var(--font-terminal);
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
   }
   article p {
     color: var(--red-accent);

--- a/src/modules/portfolio/components/ExperienceCard.astro
+++ b/src/modules/portfolio/components/ExperienceCard.astro
@@ -126,6 +126,11 @@ const { lang, name, position, url, startDate, endDate, summary, highlights, team
     color: var(--red-muted);
     transition: color 0.3s ease;
   }
+  time {
+    font-family: var(--font-terminal);
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+  }
   article:hover .period-wrapper {
     color: var(--cyan-muted);
     transition: color 0.3s ease;
@@ -158,9 +163,10 @@ const { lang, name, position, url, startDate, endDate, summary, highlights, team
     padding-left: 0.8rem;
   }
   h3 {
+    font-family: var(--font-terminal);
     color: var(--red-accent);
     font-weight: lighter;
-    font-size: large;
+    font-size: 1.4rem;
     transition: color 0.3s ease;
   }
   article:hover h3 {

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -68,12 +68,14 @@ const { lang, name, label } = Astro.props;
 		margin-top: -10rem;
 	}
 	h1 {
-		font-size: clamp(1.5em, 8vw, 2.5em);
+		font-family: var(--font-display);
+		font-size: var(--fs-display);
+		font-weight: 600;
 		color: var(--red-glow);
 		text-shadow: 0 0 15px var(--red-glow);
 	}
 	h2 {
-		font-size: clamp(0.5em, 4vw, 1.25em);
+		font-size: var(--fs-lead);
 		font-weight: 400;
 		margin-bottom: 1.5em;
 		color: var(--red-core);

--- a/src/modules/portfolio/components/ProjectsCard.astro
+++ b/src/modules/portfolio/components/ProjectsCard.astro
@@ -129,6 +129,9 @@ const { id, name, image, summary, description, technologies, url, repo } = Astro
     gap: 0.8rem;
   }
   .content h4 {
+    font-family: var(--font-display);
+    font-size: var(--fs-lead);
+    font-weight: 600;
     color: var(--red-glow);
   }
   .content p {

--- a/src/modules/portfolio/components/ProjectsDetail.astro
+++ b/src/modules/portfolio/components/ProjectsDetail.astro
@@ -141,6 +141,10 @@ const { lang, projects } = Astro.props;
     border-radius: 6px 6px 0 0;
     z-index: 1;
   }
+  header h3 {
+    font-family: var(--font-display);
+    letter-spacing: 0.06em;
+  }
   article {
     width: 100%;
     background-color: var(--bg-base);
@@ -165,6 +169,9 @@ const { lang, projects } = Astro.props;
     gap: 0.5rem;
   }
   h4 {
+    font-family: var(--font-terminal);
+    font-size: 1.4rem;
+    letter-spacing: 0.02em;
     color: var(--red-accent);
   }
   .highlights {

--- a/src/modules/portfolio/components/Section.astro
+++ b/src/modules/portfolio/components/Section.astro
@@ -53,12 +53,17 @@ const { id, title, subTittle, styles } = Astro.props;
   }
 
   h1 {
+    font-family: var(--font-display);
+    font-size: var(--fs-title);
+    font-weight: 600;
     color: var(--red-glow);
     text-shadow: 0 0 15px var(--red-glow);
     text-transform: uppercase;
   }
   p {
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-terminal);
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
     text-transform: uppercase;
     color: var(--red-muted);
   }

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -1,5 +1,10 @@
 ---
 import '@fontsource-variable/orbitron';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-mono/400-italic.css';
+import '@fontsource/vt323/400.css';
 
 import NavBar from './components/NavBar.astro';
 import Footer from './components/Footer.astro';
@@ -92,10 +97,22 @@ const { title, image, summary, url, lang, links } = Astro.props;
 		--cream: #fff7ed;
 		--glitch-label-bg: #212121;
 		--white-transparent: rgba(255, 255, 255, 0);
+
+		/* TIPOGRAFÍA · 3 voces */
+		--font-display: 'Orbitron Variable', sans-serif;      /* nombre, headers, etiquetas de panel, CTA */
+		--font-body: 'IBM Plex Mono', 'Courier New', Courier, monospace; /* cuerpo, datos, UI */
+		--font-terminal: 'VT323', 'Courier New', Courier, monospace;     /* sabor terminal: prompts, timestamps */
+
+		/* ESCALA tipográfica */
+		--fs-display: clamp(2rem, 6vw, 3rem);    /* ~48 / 600 */
+		--fs-title: clamp(1.5rem, 4vw, 1.75rem); /* ~28 / 600 */
+		--fs-lead: 1.125rem;                     /* ~18 */
+		--fs-body: 0.9375rem;                    /* ~15 */
+		--fs-meta: 0.75rem;                      /* ~12 */
 	}
 
 	html {
-		font-family: 'Orbitron Variable', sans-serif;
+		font-family: var(--font-body);
 		scroll-behavior: smooth;
 	}
 
@@ -113,6 +130,8 @@ const { title, image, summary, url, lang, links } = Astro.props;
 	body {
 		background-color: color-mix(in srgb, var(--bg-base) 100%, transparent);
 		color: var(--red-core);
+		font-size: var(--fs-body);
+		line-height: 1.6;
   }
 
 	* {

--- a/src/modules/portfolio/layout/components/NavBar.astro
+++ b/src/modules/portfolio/layout/components/NavBar.astro
@@ -169,6 +169,7 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 		transition: 0.3s;
 	}
 	h1 {
+		font-family: var(--font-display);
 		color: var(--red-core);
 		padding: 0.2em 0.4em;
 		border-radius: 5px;


### PR DESCRIPTION
## Resumen

Paso 3 de la secuencia. Implementa el **sistema tipográfico de 3 voces**, tokenizado como variables CSS, sobre los pasos 1 (tokens de color) y 2 (recolor HLCS) ya integrados en `dev`. **Solo tipografía** — sin cambios de color, glow, CRT, layout ni hero.

El cambio visible principal: el **cuerpo pasa de Orbitron a IBM Plex Mono**, mucho más legible para texto de lectura.

## Cambios

### Fuentes (auto-hospedadas, `font-display: swap`)
- **IBM Plex Mono** — pesos 400, 500, 600 + itálica 400 (`@fontsource/ibm-plex-mono`).
- **VT323** — peso 400 (`@fontsource/vt323`).
- Orbitron variable se mantiene igual. No se cargan pesos sin usar.

### Tokens en `:root` (`portfolio/layout/Layout.astro`)
- `--font-display` → Orbitron
- `--font-body` → IBM Plex Mono (fuente base del `body`)
- `--font-terminal` → VT323
- Escala: `--fs-display` (~48/600), `--fs-title` (~28/600), `--fs-lead` (~18), `--fs-body` (~15), `--fs-meta` (~12)

### Roles asignados
| Voz | Fuente | Dónde |
|-----|--------|-------|
| **Display** | Orbitron | Nombre (hero + logo nav), headers de sección, etiquetas de panel (`Contact_interface`, header de detalle de proyecto), títulos de tarjeta de proyecto y **todos los CTA** (`ButtonGlitch`: Ver proyectos, Iniciar contacto, Currículum, Contacto, Enviar, Ver Código/Demo) |
| **Body** | IBM Plex Mono | Todo el texto de lectura, párrafos, datos, UI, enlaces de nav y menores |
| **Terminal** | VT323 | Solo el sabor terminal ya existente: subtítulos con prompt `>` (`REGISTRO_PERSONAL`, etc.), `> Logros Clave:` / `> MISSION_BRIEF`, `> ENVIAR MENSAJE` y timestamps |

En `ButtonGlitch` se bajó el `letter-spacing` de `0.2em` a `0.12em` para dar aire (Orbitron es ancha); no se forzó `uppercase` para evitar desbordes en CTA largos en español (p. ej. "Iniciar el contacto").

## Verificación
- `npm run build` en verde.
- Las 3 fuentes cargan (200, woff2), sin 404 de fuentes; aplicadas a los roles correctos (`body`→IBM Plex Mono, nombre/headers/CTA→Orbitron, subtítulos/timestamps→VT323).
- Revisado en **desktop (1280) y móvil (390)**, en **ES y EN**: sin overflow horizontal (`scrollWidth == innerWidth`) ni texto cortado.
- IBM Plex Mono es monoespaciada (más ancha): revisado nav, chips, botones y tarjetas — sin roturas. El email en la tarjeta de contacto encaja (y en mono es más estrecho que en la Orbitron previa).
- Sin errores de consola relacionados con tipografía (las advertencias de recursos son imágenes externas de Unsplash bloqueadas por el proxy del entorno, no fuentes).

## Notas
- Rama basada en `dev` (no `prod`), para revisar y desplegar antes del paso 4.
- Sin screenshots adjuntos en el PR (las imágenes externas no cargan en el entorno de build), pero el layout se verificó por captura local en ambos idiomas y viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01938YdzU9HDYZHAJ5idLHwm)_