### PR TITLE
feat(crt): glow de fósforo por rol + overlay CRT (paso 4)

### DIFF
--- a/src/modules/portfolio/components/Contact.astro
+++ b/src/modules/portfolio/components/Contact.astro
@@ -222,6 +222,7 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
     border: 2px solid var(--cyan-glow);
     background-color: var(--cyan-muted);
     color: var(--cyan-core);
+    text-shadow: var(--text-glow-cyan);
     box-shadow: 0 0 10px var(--cyan-glow);
     scale: 1.05;
     transition: all 0.3s ease;

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -14,7 +14,7 @@ const { lang, name, label } = Astro.props;
 <section class="home" id="home">
 	<Logo />
 	<article>
-		<h1>{name.toLocaleUpperCase()}</h1>
+		<h1 class="glow-red">{name.toLocaleUpperCase()}</h1>
 		<h2>{"> "}{ label}</h2>
 		<div class="button-container">
 			<ButtonGlitch
@@ -71,8 +71,7 @@ const { lang, name, label } = Astro.props;
 		font-family: var(--font-display);
 		font-size: var(--fs-display);
 		font-weight: 600;
-		color: var(--red-glow);
-		text-shadow: 0 0 15px var(--red-glow);
+		/* color + glow los aporta la utilidad global .glow-red */
 	}
 	h2 {
 		font-size: var(--fs-lead);

--- a/src/modules/portfolio/components/Section.astro
+++ b/src/modules/portfolio/components/Section.astro
@@ -17,7 +17,7 @@ const { id, title, subTittle, styles } = Astro.props;
   <header>
     {title && <div class="title-wrapper">
       <div class="experience-title-line" />
-      <h1>{title}</h1>
+      <h1 class="glow-red">{title}</h1>
     </div>}
     {subTittle && <p>{">"} {subTittle}</p>}
   </header>
@@ -56,8 +56,7 @@ const { id, title, subTittle, styles } = Astro.props;
     font-family: var(--font-display);
     font-size: var(--fs-title);
     font-weight: 600;
-    color: var(--red-glow);
-    text-shadow: 0 0 15px var(--red-glow);
+    /* color + glow los aporta la utilidad global .glow-red */
     text-transform: uppercase;
   }
   p {

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -88,6 +88,15 @@ const { title, image, summary, url, lang, links } = Astro.props;
 		--amber-glow: #FFB000;
 		--amber-core: #FFE9C2;
 
+		/* GLOW · text-shadow de fósforo en 3 capas (núcleo + halo + bloom).
+		   Recetas reutilizables; se aplican vía .glow-red / .glow-cyan / .glow-amber. */
+		--text-glow-red: 0 0 1px currentColor, 0 0 8px var(--red-glow),
+			0 0 22px color-mix(in srgb, var(--red-glow) 55%, transparent);
+		--text-glow-cyan: 0 0 1px currentColor, 0 0 8px var(--cyan-glow),
+			0 0 20px color-mix(in srgb, var(--cyan-glow) 45%, transparent);
+		--text-glow-amber: 0 0 1px currentColor, 0 0 8px var(--amber-glow),
+			0 0 16px color-mix(in srgb, var(--amber-glow) 55%, transparent);
+
 		/* FONDO · rampa cálida */
 		--bg-field: #080404;
 		--bg-base: #151111;
@@ -148,9 +157,60 @@ const { title, image, summary, url, lang, links } = Astro.props;
 		object-position: center center;
 	}
 
+	/* ===== Utilidades de glow de fósforo (por rol) ===== */
+	.glow-red   { color: var(--red-glow);   text-shadow: var(--text-glow-red); }
+	.glow-cyan  { color: var(--cyan-glow);  text-shadow: var(--text-glow-cyan); }
+	.glow-amber { color: var(--amber-glow); text-shadow: var(--text-glow-amber); }
+
+	/* ===== Overlay CRT global: scanlines + viñeta + flicker =====
+	   Fijo, por encima del contenido, nunca captura clicks. El cuerpo se mantiene
+	   legible: las scanlines usan multiply (casi invisibles sobre el fondo oscuro,
+	   solo cortan el texto/fósforo brillante) y la viñeta solo oscurece los bordes. */
+	body::before,
+	body::after {
+		content: "";
+		position: fixed;
+		inset: 0;
+		pointer-events: none;
+		z-index: 1000;
+	}
+	/* Viñeta */
+	body::before {
+		background: radial-gradient(
+			ellipse at center,
+			transparent 60%,
+			color-mix(in srgb, var(--bg-field) 55%, transparent) 100%
+		);
+	}
+	/* Scanlines + flicker */
+	body::after {
+		background: repeating-linear-gradient(
+			to bottom,
+			rgba(0, 0, 0, 0.14) 0px,
+			rgba(0, 0, 0, 0.14) 1px,
+			transparent 1px,
+			transparent 3px
+		);
+		mix-blend-mode: multiply;
+		opacity: 0.6;
+		animation: crt-flicker 7s ease-in-out infinite;
+	}
+
+	@keyframes crt-flicker {
+		0%, 88%, 100% { opacity: 0.6; }
+		90% { opacity: 0.54; }
+		92% { opacity: 0.63; }
+		94% { opacity: 0.5; }
+		96% { opacity: 0.6; }
+	}
+
   @media (prefers-reduced-motion: reduce) {
     html {
       scroll-behavior: auto;
+    }
+    /* Sin parpadeo; las scanlines/viñeta quedan estáticas y sutiles. */
+    body::after {
+      animation: none;
     }
   }
 	

--- a/src/modules/portfolio/layout/components/Footer.astro
+++ b/src/modules/portfolio/layout/components/Footer.astro
@@ -102,5 +102,10 @@ const { lang } = Astro.props;
 		position: relative;
 		color: var(--red-core);
 		z-index: 5;
+		transition: 0.3s ease;
+	}
+	a:hover {
+		color: var(--cyan-glow);
+		text-shadow: var(--text-glow-cyan);
 	}
 </style>

--- a/src/modules/portfolio/layout/components/NavBar.astro
+++ b/src/modules/portfolio/layout/components/NavBar.astro
@@ -190,6 +190,7 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 	.active {
 		border: 1px solid var(--red-glow);
 		color: var(--red-glow);
+		text-shadow: var(--text-glow-red);
 		box-shadow: 0px 0px 10px 0px var(--red-accent);
 		background-color: color-mix(in srgb, var(--red-accent) 10%, transparent);
 		scale: 1.05;


### PR DESCRIPTION
- Utilidades reutilizables .glow-red/.glow-cyan/.glow-amber (text-shadow de 3 capas: núcleo + halo + bloom) y tokens --text-glow-* en :root.
- Rojo: nombre (Home) y headers de sección migrados a .glow-red; el nav item activo enciende en rojo. Sin recolor: mismo color, glow más rico.
- Cian sutil: glow de fósforo en hover de links (footer, tarjetas de contacto) reutilizando la receta.
- Overlay CRT global (scanlines multiply + viñeta + flicker), position:fixed, pointer-events:none, z-index 1000 (sobre el contenido, bajo el modal móvil). Scanlines en multiply: casi invisibles sobre el fondo, solo cortan el fósforo; el cuerpo sigue tan legible como en el paso 3.
- Ámbar: utilidad .glow-amber definida y reservada (aplicación real en pasos posteriores, según el plan).
- prefers-reduced-motion: reduce desactiva el flicker.