### PR TITLE
feat(design-system): página /design-system HLCS (paso 7)

### DIFF
--- a/src/modules/design-system/DesignSystem.astro
+++ b/src/modules/design-system/DesignSystem.astro
@@ -1,0 +1,799 @@
+---
+/*
+  ============================================================================
+  HLCS · Sistema de diseño — página pública secundaria (paso 7)
+  ============================================================================
+  Esta página NO redibuja ni hardcodea el sistema: se alimenta de los tokens y
+  componentes REALES del sitio, para que sea imposible que se desincronice.
+
+  · Los swatches pintan con `background: var(--red-glow)` etc. (token real).
+  · El hex mostrado como texto se LEE en runtime con getComputedStyle sobre
+    :root (ver <script> al final). Si el token cambia en el :root del Layout,
+    el swatch y su etiqueta cambian solos.
+  · El ejemplo de botón importa y renderiza el ButtonGlitch.astro REAL.
+  · Las fuentes (Orbitron / IBM Plex Mono / VT323) y las utilidades .glow-*
+    son las declaradas globalmente en el Layout (paso 4).
+
+  Fuente escrita de referencia: DESIGN_SYSTEM.md en el repo.
+  Alcance aditivo: esta página solo USA el resto del sitio, no lo modifica.
+  ============================================================================
+*/
+import ButtonGlitch from '../portfolio/components/ButtonGlitch.astro';
+
+interface Props {
+  lang: 'es' | 'en' | string;
+}
+
+const { lang } = Astro.props;
+const es = lang === 'es';
+
+// ---- Diccionario i18n (es/en) siguiendo el patrón bilingüe del repo --------
+const t = {
+  meta: {
+    kicker: es ? 'Sistema de diseño' : 'Design system',
+    title: 'HLCS',
+    full: 'Hardcode Labs Computer Systems',
+    philosophy: es
+      ? 'Casi todo apagado; pocas cosas encienden — la escasez es potencia.'
+      : 'Almost everything off; few things ignite — scarcity is power.',
+    intro: es
+      ? 'Esta página se alimenta de los tokens y componentes reales del sitio. Lo que ves aquí es el propio sistema mostrándose a sí mismo.'
+      : 'This page feeds from the real tokens and components of the site. What you see here is the system showing itself.',
+  },
+  principle: {
+    heading: es ? 'Principio rector' : 'Guiding principle',
+    warm: es ? 'Cálido = identidad y acción' : 'Warm = identity and action',
+    warmBody: es
+      ? 'El rojo enciende lo que somos y lo que hay que pulsar: nombre, marca, llamadas a la acción, alertas.'
+      : 'Red ignites who we are and what to press: name, brand, calls to action, alerts.',
+    cold: es ? 'Frío = datos' : 'Cold = data',
+    coldBody: es
+      ? 'El cian se reserva para información nominal: datos, enlaces, estado del sistema.'
+      : 'Cyan is reserved for nominal information: data, links, system status.',
+  },
+  color: {
+    heading: es ? 'Color' : 'Color',
+    lead: es
+      ? 'Tres registros. El hex de cada muestra se lee en runtime desde el token — no está escrito a mano.'
+      : 'Three registers. Each swatch’s hex is read at runtime from the token — never hand-written.',
+    registers: [
+      {
+        name: es ? 'Rojo · identidad / alerta' : 'Red · identity / alert',
+        swatches: [
+          { token: '--red-glow', role: es ? 'Identidad, acción, alerta — el rojo que enciende' : 'Identity, action, alert — the red that ignites' },
+          { token: '--red-core', role: es ? 'Texto sobre fondo oscuro (blanco cálido)' : 'Text on dark background (warm near-white)' },
+          { token: '--red-accent', role: es ? 'Profundidad y estados hover' : 'Depth and hover states' },
+          { token: '--red-muted', role: es ? 'Bordes y rejillas apagadas' : 'Muted borders and grids' },
+        ],
+      },
+      {
+        name: es ? 'Cian · datos / nominal' : 'Cyan · data / nominal',
+        swatches: [
+          { token: '--cyan-glow', role: es ? 'Datos, enlaces, estado nominal — el frío' : 'Data, links, nominal state — the cold' },
+          { token: '--cyan-core', role: es ? 'Texto de datos de alto contraste' : 'High-contrast data text' },
+          { token: '--cyan-accent', role: es ? 'Halos y sombras de datos' : 'Data halos and shadows' },
+          { token: '--cyan-muted', role: es ? 'Fondos de panel de datos' : 'Data panel backgrounds' },
+        ],
+      },
+      {
+        name: es ? 'Ámbar · señal' : 'Amber · signal',
+        swatches: [
+          { token: '--amber-glow', role: es ? 'Señal — cursor, boot, advertencias (uso real en pasos posteriores)' : 'Signal — cursor, boot, warnings (real use in later steps)' },
+          { token: '--amber-core', role: es ? 'Resaltado suave de señal' : 'Soft signal highlight' },
+        ],
+      },
+    ],
+    proportion: es ? 'Proporción de uso' : 'Usage proportion',
+    proportionNote: es
+      ? '~74 % fondo · 15 % rojo · 8 % cian · 3 % ámbar. El color es la excepción, no la norma.'
+      : '~74% background · 15% red · 8% cyan · 3% amber. Color is the exception, not the norm.',
+  },
+  bg: {
+    heading: es ? 'Fondo' : 'Background',
+    lead: es
+      ? 'Una rampa cálida de tres pasos. Todo parte del reposo oscuro.'
+      : 'A warm three-step ramp. Everything starts from dark rest.',
+    steps: [
+      { token: '--bg-field', role: es ? 'Campo más profundo — viñeta, bordes' : 'Deepest field — vignette, edges' },
+      { token: '--bg-base', role: es ? 'Fondo base del cuerpo' : 'Body base background' },
+      { token: '--bg-raised', role: es ? 'Superficies elevadas — paneles, tarjetas' : 'Raised surfaces — panels, cards' },
+    ],
+  },
+  type: {
+    heading: es ? 'Tipografía' : 'Typography',
+    lead: es ? 'Tres voces, una escala.' : 'Three voices, one scale.',
+    voices: [
+      { font: 'var(--font-display)', name: 'Orbitron', token: '--font-display', sample: 'HLCS', role: es ? 'Nombre, headers, etiquetas de panel, CTA' : 'Name, headers, panel labels, CTA' },
+      { font: 'var(--font-body)', name: 'IBM Plex Mono', token: '--font-body', sample: 'Data 0123', role: es ? 'Cuerpo, datos, UI' : 'Body, data, UI' },
+      { font: 'var(--font-terminal)', name: 'VT323', token: '--font-terminal', sample: '> boot_ok', role: es ? 'Sabor terminal: prompts, timestamps' : 'Terminal flavor: prompts, timestamps' },
+    ],
+    scaleHeading: es ? 'Escala' : 'Scale',
+    scale: [
+      { token: '--fs-display', label: 'display' },
+      { token: '--fs-title', label: 'title' },
+      { token: '--fs-lead', label: 'lead' },
+      { token: '--fs-body', label: 'body' },
+      { token: '--fs-meta', label: 'meta' },
+    ],
+    rule: es ? 'Regla' : 'Rule',
+    ruleBody: es
+      ? 'Los botones de acción decisiva van en Orbitron (--font-display). Es la voz que ordena.'
+      : 'Decisive-action buttons use Orbitron (--font-display). It is the voice that commands.',
+  },
+  glow: {
+    heading: es ? 'Glow de fósforo' : 'Phosphor glow',
+    lead: es
+      ? 'Las utilidades reales .glow-red / .glow-cyan / .glow-amber. Úsalas con moderación.'
+      : 'The real .glow-red / .glow-cyan / .glow-amber utilities. Use them sparingly.',
+    technique: es ? 'Técnica de 3 capas' : '3-layer technique',
+    techniqueBody: es
+      ? 'Núcleo nítido + halo medio + bloom difuso, apilados en un solo text-shadow. Valor leído en runtime desde --text-glow-red:'
+      : 'Crisp core + mid halo + diffuse bloom, stacked in a single text-shadow. Value read at runtime from --text-glow-red:',
+  },
+  crt: {
+    heading: es ? 'CRT' : 'CRT',
+    lead: es
+      ? 'El overlay real —scanlines, viñeta y flicker— vive sobre todo el sitio. Aquí puedes apagarlo para verlo.'
+      : 'The real overlay — scanlines, vignette and flicker — lives over the whole site. Here you can toggle it off to see it.',
+    on: es ? 'CRT encendido' : 'CRT on',
+    off: es ? 'CRT apagado' : 'CRT off',
+    toggle: es ? 'Alternar overlay CRT' : 'Toggle CRT overlay',
+    note: es
+      ? 'El flicker respeta prefers-reduced-motion: si lo prefieres reducido, las scanlines quedan estáticas.'
+      : 'The flicker respects prefers-reduced-motion: if you prefer reduced motion, the scanlines stay static.',
+  },
+  hierarchy: {
+    heading: es ? 'Jerarquía' : 'Hierarchy',
+    lead: es ? 'Checklist de 6 pasos para armar una página nueva.' : '6-step checklist for building a new page.',
+    steps: es
+      ? [
+          'Empieza apagado — fondo base, casi todo en reposo.',
+          'Un solo registro cálido por vista para identidad y acción.',
+          'El frío (cian) solo para datos y enlaces.',
+          'Orbitron para títulos y CTA · Plex Mono para cuerpo · VT323 para sabor terminal.',
+          'Glow con moderación — reserva el fósforo para lo que debe encender.',
+          'Aplica el CRT y respeta prefers-reduced-motion y el foco de teclado.',
+        ]
+      : [
+          'Start off — base background, almost everything at rest.',
+          'One warm register per view for identity and action.',
+          'Cold (cyan) only for data and links.',
+          'Orbitron for titles and CTA · Plex Mono for body · VT323 for terminal flavor.',
+          'Glow sparingly — reserve the phosphor for what must ignite.',
+          'Apply the CRT and respect prefers-reduced-motion and keyboard focus.',
+        ],
+  },
+  components: {
+    heading: es ? 'Componentes' : 'Components',
+    lead: es
+      ? 'El ButtonGlitch real, renderizado aquí con el mismo comportamiento del sitio.'
+      : 'The real ButtonGlitch, rendered here with the same behavior as the site.',
+    primary: es ? 'Acción primaria' : 'Primary action',
+    secondary: es ? 'Acción secundaria' : 'Secondary action',
+    disabled: es ? 'Deshabilitado' : 'Disabled',
+    promptHeading: es ? 'Convención de prompt' : 'Prompt convention',
+    promptBody: es
+      ? 'El carácter > abre una línea; la etiqueta en mayúsculas nombra el registro.'
+      : 'The > character opens a line; the uppercase label names the register.',
+  },
+  footerNote: es
+    ? 'Fuente escrita: DESIGN_SYSTEM.md · Esta página se sincroniza sola con los tokens del sitio.'
+    : 'Written source: DESIGN_SYSTEM.md · This page stays in sync with the site tokens on its own.',
+};
+---
+
+<main class="ds" aria-labelledby="ds-title">
+  <!-- 1 · Portada -->
+  <header class="ds-hero">
+    <p class="ds-kicker glow-amber">{t.meta.kicker}</p>
+    <h1 id="ds-title" class="ds-hero-title glow-red">{t.meta.title}</h1>
+    <p class="ds-hero-full">{t.meta.full}</p>
+    <p class="ds-hero-philosophy">{t.meta.philosophy}</p>
+    <p class="ds-hero-intro">{t.meta.intro}</p>
+  </header>
+
+  <!-- 2 · Principio rector -->
+  <section class="ds-section" aria-labelledby="ds-principle">
+    <h2 id="ds-principle" class="ds-h2">{t.principle.heading}</h2>
+    <div class="ds-principle-grid">
+      <article class="ds-card ds-card--warm">
+        <h3 class="ds-h3 glow-red">{t.principle.warm}</h3>
+        <p>{t.principle.warmBody}</p>
+      </article>
+      <article class="ds-card ds-card--cold">
+        <h3 class="ds-h3 glow-cyan">{t.principle.cold}</h3>
+        <p>{t.principle.coldBody}</p>
+      </article>
+    </div>
+  </section>
+
+  <!-- 3 · Color -->
+  <section class="ds-section" aria-labelledby="ds-color">
+    <h2 id="ds-color" class="ds-h2">{t.color.heading}</h2>
+    <p class="ds-lead">{t.color.lead}</p>
+
+    {t.color.registers.map((reg) => (
+      <div class="ds-register">
+        <h3 class="ds-h3">{reg.name}</h3>
+        <ul class="ds-swatches" role="list">
+          {reg.swatches.map((sw) => (
+            <li class="ds-swatch">
+              {/* El swatch pinta con el token real; el hex se rellena en runtime */}
+              <span class="ds-swatch-chip" style={`background: var(${sw.token});`} aria-hidden="true"></span>
+              <span class="ds-swatch-meta">
+                <code class="ds-swatch-token">{sw.token}</code>
+                <span class="ds-swatch-hex" data-token={sw.token}>…</span>
+                <span class="ds-swatch-role">{sw.role}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))}
+
+    <div class="ds-proportion">
+      <h3 class="ds-h3">{t.color.proportion}</h3>
+      <div class="ds-proportion-bar" role="img" aria-label={t.color.proportionNote}>
+        <span class="ds-prop-seg" style="flex: 74; background: var(--bg-raised);"><i>74</i></span>
+        <span class="ds-prop-seg" style="flex: 15; background: var(--red-glow);"><i>15</i></span>
+        <span class="ds-prop-seg" style="flex: 8; background: var(--cyan-glow);"><i>8</i></span>
+        <span class="ds-prop-seg" style="flex: 3; background: var(--amber-glow);"><i>3</i></span>
+      </div>
+      <p class="ds-meta">{t.color.proportionNote}</p>
+    </div>
+  </section>
+
+  <!-- 4 · Fondo -->
+  <section class="ds-section" aria-labelledby="ds-bg">
+    <h2 id="ds-bg" class="ds-h2">{t.bg.heading}</h2>
+    <p class="ds-lead">{t.bg.lead}</p>
+    <ul class="ds-ramp" role="list">
+      {t.bg.steps.map((step) => (
+        <li class="ds-ramp-step">
+          <span class="ds-ramp-fill" style={`background: var(${step.token});`} aria-hidden="true"></span>
+          <code class="ds-swatch-token">{step.token}</code>
+          <span class="ds-swatch-hex" data-token={step.token}>…</span>
+          <span class="ds-swatch-role">{step.role}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <!-- 5 · Tipografía -->
+  <section class="ds-section" aria-labelledby="ds-type">
+    <h2 id="ds-type" class="ds-h2">{t.type.heading}</h2>
+    <p class="ds-lead">{t.type.lead}</p>
+
+    <ul class="ds-voices" role="list">
+      {t.type.voices.map((v) => (
+        <li class="ds-voice">
+          <span class="ds-voice-sample" style={`font-family: ${v.font};`}>{v.sample}</span>
+          <span class="ds-voice-meta">
+            <strong>{v.name}</strong>
+            <code class="ds-swatch-token">{v.token}</code>
+            <span class="ds-swatch-role">{v.role}</span>
+          </span>
+        </li>
+      ))}
+    </ul>
+
+    <div class="ds-scale">
+      <h3 class="ds-h3">{t.type.scaleHeading}</h3>
+      <ul role="list">
+        {t.type.scale.map((s) => (
+          <li class="ds-scale-row">
+            <span class="ds-scale-sample" style={`font-size: var(${s.token});`}>Aa</span>
+            <code class="ds-swatch-token">{s.token}</code>
+            <span class="ds-scale-size" data-fs={s.token}>…</span>
+            <span class="ds-swatch-role">{s.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    <p class="ds-rule"><strong class="glow-red">{t.type.rule}:</strong> {t.type.ruleBody}</p>
+  </section>
+
+  <!-- 6 · Glow de fósforo -->
+  <section class="ds-section" aria-labelledby="ds-glow">
+    <h2 id="ds-glow" class="ds-h2">{t.glow.heading}</h2>
+    <p class="ds-lead">{t.glow.lead}</p>
+    <div class="ds-glow-demo">
+      <span class="glow-red">glow-red</span>
+      <span class="glow-cyan">glow-cyan</span>
+      <span class="glow-amber">glow-amber</span>
+    </div>
+    <div class="ds-technique">
+      <h3 class="ds-h3">{t.glow.technique}</h3>
+      <p>{t.glow.techniqueBody}</p>
+      {/* El valor de la receta se lee en runtime desde --text-glow-red */}
+      <pre class="ds-code"><code data-recipe="--text-glow-red">…</code></pre>
+    </div>
+  </section>
+
+  <!-- 7 · CRT -->
+  <section class="ds-section" aria-labelledby="ds-crt">
+    <h2 id="ds-crt" class="ds-h2">{t.crt.heading}</h2>
+    <p class="ds-lead">{t.crt.lead}</p>
+    <button
+      type="button"
+      id="ds-crt-toggle"
+      class="ds-toggle"
+      aria-pressed="true"
+      data-on={t.crt.on}
+      data-off={t.crt.off}
+    >
+      <span class="ds-toggle-dot" aria-hidden="true"></span>
+      <span class="ds-toggle-label">{t.crt.on}</span>
+      <span class="ds-sr-only">{t.crt.toggle}</span>
+    </button>
+    <p class="ds-meta">{t.crt.note}</p>
+  </section>
+
+  <!-- 8 · Jerarquía -->
+  <section class="ds-section" aria-labelledby="ds-hierarchy">
+    <h2 id="ds-hierarchy" class="ds-h2">{t.hierarchy.heading}</h2>
+    <p class="ds-lead">{t.hierarchy.lead}</p>
+    <ol class="ds-checklist">
+      {t.hierarchy.steps.map((step, i) => (
+        <li class="ds-checklist-item">
+          <span class="ds-checklist-num glow-cyan" aria-hidden="true">{String(i + 1).padStart(2, '0')}</span>
+          <span>{step}</span>
+        </li>
+      ))}
+    </ol>
+  </section>
+
+  <!-- 9 · Componentes -->
+  <section class="ds-section" aria-labelledby="ds-components">
+    <h2 id="ds-components" class="ds-h2">{t.components.heading}</h2>
+    <p class="ds-lead">{t.components.lead}</p>
+
+    <div class="ds-buttons">
+      <div class="ds-button-cell">
+        <ButtonGlitch text="INICIAR" color="primary" width="auto" />
+        <span class="ds-meta">{t.components.primary}</span>
+      </div>
+      <div class="ds-button-cell">
+        <ButtonGlitch text="CONSULTAR" color="secondary" width="auto" />
+        <span class="ds-meta">{t.components.secondary}</span>
+      </div>
+      <div class="ds-button-cell">
+        <ButtonGlitch text="BLOQUEADO" color="primary" width="auto" disabled={true} />
+        <span class="ds-meta">{t.components.disabled}</span>
+      </div>
+    </div>
+
+    <div class="ds-prompt">
+      <h3 class="ds-h3">{t.components.promptHeading}</h3>
+      <p>{t.components.promptBody}</p>
+      <p class="ds-prompt-line"><span class="glow-amber">&gt;</span> REGISTRO_PERSONAL</p>
+    </div>
+  </section>
+
+  <p class="ds-footnote">{t.footerNote}</p>
+</main>
+
+<!--
+  Sincronización en runtime: leemos los valores REALES de los tokens desde
+  :root (getComputedStyle). Si cambia un token en el :root del Layout, estas
+  etiquetas cambian solas — la página no repite ningún valor a mano.
+-->
+<script>
+  const root = getComputedStyle(document.documentElement);
+  const read = (name: string) => root.getPropertyValue(name).trim();
+
+  // Hex de cada swatch (color · fondo)
+  document.querySelectorAll<HTMLElement>('[data-token]').forEach((el) => {
+    const token = el.dataset.token;
+    if (token) el.textContent = read(token) || '—';
+  });
+
+  // Tamaño computado de la escala tipográfica (px reales)
+  document.querySelectorAll<HTMLElement>('[data-fs]').forEach((el) => {
+    const token = el.dataset.fs;
+    if (!token) return;
+    const probe = document.createElement('span');
+    probe.style.fontSize = `var(${token})`;
+    probe.style.position = 'absolute';
+    probe.style.visibility = 'hidden';
+    document.body.appendChild(probe);
+    el.textContent = getComputedStyle(probe).fontSize;
+    probe.remove();
+  });
+
+  // Receta de glow leída del token
+  document.querySelectorAll<HTMLElement>('[data-recipe]').forEach((el) => {
+    const token = el.dataset.recipe;
+    if (token) el.textContent = `${token}: ${read(token)};`;
+  });
+
+  // Toggle del overlay CRT real (global). Aditivo: solo actúa al pulsar.
+  const toggle = document.getElementById('ds-crt-toggle');
+  if (toggle) {
+    const label = toggle.querySelector('.ds-toggle-label');
+    toggle.addEventListener('click', () => {
+      const off = document.body.classList.toggle('hlcs-crt-off');
+      toggle.setAttribute('aria-pressed', String(!off));
+      if (label) label.textContent = off ? toggle.dataset.off ?? '' : toggle.dataset.on ?? '';
+    });
+  }
+</script>
+
+<!-- Estilo global mínimo: apaga el overlay CRT real cuando el usuario lo alterna.
+     Solo se activa con la clase en <body>, así no afecta al resto del sitio. -->
+<style is:global>
+  body.hlcs-crt-off::before,
+  body.hlcs-crt-off::after {
+    display: none !important;
+  }
+</style>
+
+<style>
+  .ds {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 4vw, 2.5rem) 4rem;
+    position: relative;
+    z-index: 2;
+  }
+
+  .ds-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ---- Portada ---- */
+  .ds-hero {
+    text-align: center;
+    padding-bottom: clamp(2rem, 6vw, 4rem);
+    border-bottom: 1px solid color-mix(in srgb, var(--red-muted) 40%, transparent);
+    margin-bottom: clamp(2rem, 5vw, 3.5rem);
+  }
+  .ds-kicker {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+  }
+  .ds-hero-title {
+    font-family: var(--font-display);
+    font-size: var(--fs-display);
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    line-height: 1.1;
+  }
+  .ds-hero-full {
+    font-family: var(--font-display);
+    font-size: var(--fs-body);
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--red-core);
+    opacity: 0.8;
+    margin-top: 0.5rem;
+  }
+  .ds-hero-philosophy {
+    font-size: var(--fs-lead);
+    color: var(--cyan-core);
+    max-width: 32ch;
+    margin: 1.5rem auto 0;
+    font-style: italic;
+  }
+  .ds-hero-intro {
+    font-size: var(--fs-body);
+    color: color-mix(in srgb, var(--red-core) 80%, transparent);
+    max-width: 60ch;
+    margin: 1rem auto 0;
+  }
+
+  /* ---- Secciones ---- */
+  .ds-section {
+    margin-bottom: clamp(2.5rem, 6vw, 4.5rem);
+  }
+  .ds-h2 {
+    font-family: var(--font-display);
+    font-size: var(--fs-title);
+    color: var(--red-glow);
+    text-shadow: var(--text-glow-red);
+    letter-spacing: 0.08em;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--red-muted) 50%, transparent);
+    margin-bottom: 1.25rem;
+  }
+  .ds-h3 {
+    font-family: var(--font-display);
+    font-size: var(--fs-lead);
+    color: var(--red-core);
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+  }
+  .ds-lead {
+    font-size: var(--fs-lead);
+    color: color-mix(in srgb, var(--red-core) 85%, transparent);
+    max-width: 62ch;
+    margin-bottom: 1.5rem;
+  }
+  .ds-meta {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-meta);
+    color: var(--cyan-accent);
+    letter-spacing: 0.05em;
+  }
+
+  /* ---- Principio rector ---- */
+  .ds-principle-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
+  .ds-card {
+    background: var(--bg-raised);
+    border-radius: 10px;
+    padding: 1.5rem;
+    border: 1px solid transparent;
+  }
+  .ds-card p { color: color-mix(in srgb, var(--red-core) 85%, transparent); }
+  .ds-card--warm { border-color: color-mix(in srgb, var(--red-glow) 40%, transparent); }
+  .ds-card--cold { border-color: color-mix(in srgb, var(--cyan-glow) 40%, transparent); }
+
+  /* ---- Color · swatches ---- */
+  .ds-register { margin-bottom: 2rem; }
+  .ds-swatches {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+  .ds-swatch {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    background: var(--bg-raised);
+    border-radius: 8px;
+    padding: 0.75rem;
+  }
+  .ds-swatch-chip {
+    flex: 0 0 auto;
+    width: 44px;
+    height: 44px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, var(--cream) 20%, transparent);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.3);
+  }
+  .ds-swatch-meta { display: flex; flex-direction: column; gap: 0.15rem; min-width: 0; }
+  .ds-swatch-token {
+    font-family: var(--font-body);
+    font-size: var(--fs-meta);
+    color: var(--cyan-glow);
+  }
+  .ds-swatch-hex {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-body);
+    color: var(--red-core);
+    text-transform: uppercase;
+  }
+  .ds-swatch-role {
+    font-size: var(--fs-meta);
+    color: color-mix(in srgb, var(--red-core) 70%, transparent);
+    line-height: 1.4;
+  }
+
+  /* ---- Proporción ---- */
+  .ds-proportion { margin-top: 1rem; }
+  .ds-proportion-bar {
+    display: flex;
+    height: 44px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--red-muted) 40%, transparent);
+    margin-bottom: 0.75rem;
+  }
+  .ds-prop-seg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+  }
+  .ds-prop-seg i {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-meta);
+    font-style: normal;
+    color: var(--bg-field);
+    mix-blend-mode: difference;
+  }
+
+  /* ---- Fondo · rampa ---- */
+  .ds-ramp { list-style: none; display: grid; gap: 0.75rem; }
+  .ds-ramp-step {
+    display: grid;
+    grid-template-columns: 64px auto 1fr;
+    align-items: center;
+    gap: 0.85rem;
+    background: var(--bg-raised);
+    padding: 0.6rem 0.85rem;
+    border-radius: 8px;
+  }
+  .ds-ramp-fill {
+    height: 40px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, var(--cream) 15%, transparent);
+  }
+  .ds-ramp-step .ds-swatch-role { grid-column: 1 / -1; }
+
+  /* ---- Tipografía ---- */
+  .ds-voices { list-style: none; display: grid; gap: 1rem; margin-bottom: 2rem; }
+  .ds-voice {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    background: var(--bg-raised);
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    flex-wrap: wrap;
+  }
+  .ds-voice-sample {
+    font-size: var(--fs-title);
+    color: var(--red-core);
+    min-width: 6ch;
+  }
+  .ds-voice-meta { display: flex; flex-direction: column; gap: 0.2rem; }
+  .ds-voice-meta strong { color: var(--red-glow); font-weight: 600; }
+
+  .ds-scale ul { list-style: none; display: grid; gap: 0.5rem; }
+  .ds-scale-row {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.35rem 0;
+    border-bottom: 1px dashed color-mix(in srgb, var(--red-muted) 30%, transparent);
+  }
+  .ds-scale-sample {
+    color: var(--cyan-core);
+    line-height: 1;
+    min-width: 3ch;
+  }
+  .ds-scale-size { font-family: var(--font-terminal); color: var(--amber-glow); }
+
+  .ds-rule {
+    margin-top: 1.5rem;
+    padding: 1rem 1.25rem;
+    background: var(--bg-raised);
+    border-left: 3px solid var(--red-glow);
+    border-radius: 4px;
+    color: color-mix(in srgb, var(--red-core) 90%, transparent);
+  }
+
+  /* ---- Glow ---- */
+  .ds-glow-demo {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    padding: 2rem 1.25rem;
+    background: var(--bg-field);
+    border-radius: 10px;
+    font-family: var(--font-display);
+    font-size: var(--fs-title);
+    letter-spacing: 0.08em;
+    margin-bottom: 1.5rem;
+  }
+  .ds-technique p { color: color-mix(in srgb, var(--red-core) 85%, transparent); max-width: 62ch; }
+  .ds-code {
+    margin-top: 0.85rem;
+    background: var(--bg-field);
+    border: 1px solid color-mix(in srgb, var(--cyan-muted) 60%, transparent);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+  }
+  .ds-code code {
+    font-family: var(--font-body);
+    font-size: var(--fs-meta);
+    color: var(--cyan-core);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  /* ---- CRT toggle ---- */
+  .ds-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-family: var(--font-display);
+    font-size: var(--fs-body);
+    letter-spacing: 0.08em;
+    color: var(--cyan-glow);
+    background: var(--bg-raised);
+    border: 2px solid var(--cyan-glow);
+    border-radius: 8px;
+    padding: 0.7em 1.2em;
+    cursor: pointer;
+    transition: all 0.3s;
+    margin-bottom: 0.75rem;
+  }
+  .ds-toggle:hover,
+  .ds-toggle:focus-visible {
+    background: color-mix(in srgb, var(--cyan-glow) 15%, transparent);
+    box-shadow: 0 0 18px var(--cyan-accent);
+    outline: none;
+  }
+  .ds-toggle:focus-visible { outline: 2px solid var(--cyan-core); outline-offset: 2px; }
+  .ds-toggle-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--cyan-glow);
+    box-shadow: 0 0 10px var(--cyan-glow);
+  }
+  .ds-toggle[aria-pressed="false"] { color: var(--red-muted); border-color: var(--red-muted); }
+  .ds-toggle[aria-pressed="false"] .ds-toggle-dot { background: var(--red-muted); box-shadow: none; }
+
+  /* ---- Jerarquía ---- */
+  .ds-checklist { list-style: none; display: grid; gap: 0.85rem; counter-reset: none; }
+  .ds-checklist-item {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    background: var(--bg-raised);
+    padding: 0.85rem 1.1rem;
+    border-radius: 8px;
+    color: color-mix(in srgb, var(--red-core) 90%, transparent);
+  }
+  .ds-checklist-num {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-lead);
+    flex: 0 0 auto;
+  }
+
+  /* ---- Componentes ---- */
+  .ds-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: flex-start;
+    margin-bottom: 2rem;
+  }
+  .ds-button-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .ds-prompt p { color: color-mix(in srgb, var(--red-core) 85%, transparent); }
+  .ds-prompt-line {
+    font-family: var(--font-terminal);
+    font-size: var(--fs-title);
+    letter-spacing: 0.1em;
+    color: var(--red-core);
+    margin-top: 0.75rem;
+    background: var(--bg-field);
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    display: inline-block;
+  }
+
+  .ds-footnote {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--red-muted) 40%, transparent);
+    font-family: var(--font-terminal);
+    font-size: var(--fs-meta);
+    color: var(--cyan-accent);
+    text-align: center;
+    letter-spacing: 0.05em;
+  }
+
+  @media (max-width: 600px) {
+    .ds-voice { gap: 0.85rem; }
+    .ds-ramp-step { grid-template-columns: 48px 1fr; }
+    .ds-ramp-step .ds-swatch-hex { text-align: right; }
+  }
+</style>

--- a/src/modules/portfolio/layout/components/Footer.astro
+++ b/src/modules/portfolio/layout/components/Footer.astro
@@ -6,6 +6,10 @@ interface Props {
 }
 
 const { lang } = Astro.props;
+
+// Enlace discreto al sistema de diseño (contenido secundario: solo footer, nunca nav).
+const designSystemHref = `${import.meta.env.BASE_URL}/${lang === 'es' ? 'es' : 'en'}/sistema-de-diseno`;
+const designSystemLabel = lang === 'es' ? 'Sistema de diseño' : 'Design system';
 ---
 
 <footer>
@@ -28,6 +32,9 @@ const { lang } = Astro.props;
 		>
 			Midudev
 		</a>
+	</p>
+	<p class="footer-secondary">
+		<a href={designSystemHref} class="design-system-link">{designSystemLabel}</a>
 	</p>
 </footer>
 
@@ -107,5 +114,14 @@ const { lang } = Astro.props;
 	a:hover {
 		color: var(--cyan-glow);
 		text-shadow: var(--text-glow-cyan);
+	}
+	.footer-secondary {
+		display: block;
+		margin-top: 0.6em;
+		font-size: var(--fs-meta);
+	}
+	.design-system-link {
+		color: color-mix(in srgb, var(--red-core) 55%, transparent);
+		letter-spacing: 0.05em;
 	}
 </style>

--- a/src/modules/portfolio/layout/components/Footer.astro
+++ b/src/modules/portfolio/layout/components/Footer.astro
@@ -8,7 +8,7 @@ interface Props {
 const { lang } = Astro.props;
 
 // Enlace discreto al sistema de diseño (contenido secundario: solo footer, nunca nav).
-const designSystemHref = `${import.meta.env.BASE_URL}/${lang === 'es' ? 'es' : 'en'}/sistema-de-diseno`;
+const designSystemHref = `${import.meta.env.BASE_URL}/${lang === 'es' ? 'es' : 'en'}/design-system`;
 const designSystemLabel = lang === 'es' ? 'Sistema de diseño' : 'Design system';
 ---
 

--- a/src/pages/[lang]/design-system.astro
+++ b/src/pages/[lang]/design-system.astro
@@ -1,6 +1,6 @@
 ---
 /*
-  Ruta pública secundaria: /[lang]/sistema-de-diseno (es/en).
+  Ruta pública secundaria: /[lang]/design-system (es/en).
   Documenta el sistema de diseño HLCS alimentándose de los tokens y componentes
   REALES del sitio (ver DESIGN_SYSTEM.md). Usa el mismo Layout, glow y CRT que
   el resto del sitio. Enlazada discretamente desde el footer, ausente del nav.

--- a/src/pages/[lang]/sistema-de-diseno.astro
+++ b/src/pages/[lang]/sistema-de-diseno.astro
@@ -1,0 +1,42 @@
+---
+/*
+  Ruta pública secundaria: /[lang]/sistema-de-diseno (es/en).
+  Documenta el sistema de diseño HLCS alimentándose de los tokens y componentes
+  REALES del sitio (ver DESIGN_SYSTEM.md). Usa el mismo Layout, glow y CRT que
+  el resto del sitio. Enlazada discretamente desde el footer, ausente del nav.
+*/
+import Layout from '../../modules/portfolio/layout/Layout.astro';
+import DesignSystem from '../../modules/design-system/DesignSystem.astro';
+import { separateLanguages } from '../../shared/utils/languageSeparator';
+import resume from '../../constants/resume.json';
+
+export async function getStaticPaths() {
+  return [
+    { params: { lang: 'es' } },
+    { params: { lang: 'en' } }
+  ];
+}
+
+const { lang } = Astro.params as { lang: 'es' | 'en' };
+const isEs = lang !== 'en';
+
+const data = separateLanguages(resume, lang !== 'es' && lang !== 'en' ? 'en' : lang) as any;
+const { basics } = data;
+
+const title = isEs
+  ? 'HLCS — Sistema de diseño · Freddy Tacuri'
+  : 'HLCS — Design system · Freddy Tacuri';
+const summary = isEs
+  ? 'HLCS (Hardcode Labs Computer Systems): el sistema de diseño del sitio, alimentado por sus tokens y componentes reales.'
+  : 'HLCS (Hardcode Labs Computer Systems): the site’s design system, powered by its real tokens and components.';
+---
+
+<Layout
+  title={title}
+  image={basics.image}
+  summary={summary}
+  url={basics.url}
+  lang={lang}
+>
+  <DesignSystem lang={lang} />
+</Layout>


### PR DESCRIPTION
## Resumen

Nueva ruta pública secundaria **`/[lang]/design-system`** (es/en) que documenta el sistema de diseño **HLCS (Hardcode Labs Computer Systems)**. Es puramente **aditiva**: solo *usa* el resto del sitio, no lo modifica (salvo el enlace de footer requerido).

El slug está en inglés para ser consistente con las demás rutas del sitio (`projects`, `cv`); es neutral al idioma —sirve tanto `/es/design-system` como `/en/design-system`— y el contenido sigue siendo bilingüe.

La regla de oro se cumple: **nada hardcodeado**. La página es el propio sitio mostrándose a sí mismo.

## Cómo se mantiene sincronizada (sin hardcodear)

- **Color** — cada swatch pinta con `background: var(--token)` y el **hex se lee en runtime** con `getComputedStyle(document.documentElement).getPropertyValue('--red-glow')`. Si cambia el token en el `:root` del Layout, el swatch y su etiqueta cambian solos.
- **Tipografía** — los tamaños de la escala (`--fs-*`) se leen computados (px reales) en runtime.
- **Glow** — la receta de 3 capas se lee del token `--text-glow-red`.
- **Componentes** — el ejemplo de botón renderiza el **`ButtonGlitch.astro` real** (primario, secundario y deshabilitado), no una copia.
- **Fuentes y utilidades** — Orbitron / IBM Plex Mono / VT323 y las clases globales `glow-red/cyan/amber` tal como están declaradas en el paso 4.

## Contenido

Portada HLCS + filosofía · principio rector (cálido = identidad/acción, frío = datos) · color con los 3 registros y proporción ~74/15/8/3 · rampa de fondo de 3 pasos · tipografía (3 voces + escala + regla Orbitron para CTA) · glow de fósforo (utilidades reales + técnica de 3 capas) · CRT con **toggle on/off del overlay real** · checklist de jerarquía de 6 pasos · componentes (ButtonGlitch real + convención de prompt `>` / `REGISTRO_PERSONAL`).

> No se documentan aún el hero 3D ni la navegación terminal (pasos 5 y 6, diferidos).

## Ubicación / navegación

- Enlace **discreto desde el footer**, **ausente del nav principal**.
- Mismo Layout, glow y overlay CRT que el resto del sitio.

## Verificación

- ✅ `npm run build` pasa sin errores; se generan `/es/design-system` y `/en/design-system`.
- ✅ **Prueba de sincronización** (headless): al forzar `--red-glow: #00FF00` en `:root`, el swatch pasa a `rgb(0,255,0)` automáticamente, sin editar la página.
- ✅ Hex de todos los tokens, escala en px y receta de glow rellenados en runtime.
- ✅ Toggle CRT alterna `aria-pressed` y apaga el overlay real (`body.hlcs-crt-off`).
- ✅ Footer enlaza al slug correcto en ambos idiomas; el slug viejo `/sistema-de-diseno` devuelve 404.
- ✅ Ambos idiomas renderizan su texto; headings jerárquicos, foco de teclado y `prefers-reduced-motion` respetados.
- ✅ El `<script>` propio de la página **no** produce errores de consola.

## Nota (fuera de alcance — no modificado)

El script del `NavBar` compartido lanza dos errores **pre-existentes** que ya ocurren en todas las páginas (incluida la home y `/projects`), no introducidos por este PR:

- `Cannot read properties of undefined (reading 'classList')` — el enlace de idioma (`Translate`) no tiene `children[1]`.
- `Cannot read properties of null (reading 'offsetTop')` — el handler de scroll referencia ids de secciones (`experience`/`projects`/`contact`) que no existen en páginas secundarias.

Siguiendo el alcance del paso ("anótalo pero no lo cambies aquí"), se dejan sin tocar y se documentan para un arreglo posterior del `NavBar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUr8nR9Q62Q2JsHSprfKwh