### PR TITLE
feat(boot): secuencia de arranque FR-3D + barra de comandos opcional

### DIFF
--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -8,6 +8,8 @@ import '@fontsource/vt323/400.css';
 
 import NavBar from './components/NavBar.astro';
 import Footer from './components/Footer.astro';
+import BootSequence from './components/BootSequence.astro';
+import CommandBar from './components/CommandBar.astro';
 import MobileWarning from '../../../shared/components/MobileWarning.astro';
 import type { Link } from './constants/links';
 
@@ -48,11 +50,13 @@ const { title, image, summary, url, lang, links } = Astro.props;
   </head>
 
 	<body id="body">
+		<BootSequence lang={lang} />
 		<MobileWarning lang={lang} />
 		<div id="mouse" />
 		<NavBar lang={lang} links={links} />
 		<slot />
 		<Footer lang={lang} />
+		<CommandBar lang={lang} />
 	</body>
 </html>
 

--- a/src/modules/portfolio/layout/components/BootSequence.astro
+++ b/src/modules/portfolio/layout/components/BootSequence.astro
@@ -1,0 +1,260 @@
+---
+/*
+  Paso 6 · Boot FR-3D — capa ADITIVA de mejora progresiva.
+
+  - El contenido real vive SIEMPRE en el DOM (esto es solo un overlay decorativo
+    fijo por encima). Sin JS no se muestra nada: el atributo `hidden` lo mantiene
+    fuera hasta que el script lo activa.
+  - Corre UNA sola vez por navegador (localStorage) y es saltable (botón, tecla,
+    click o toque).
+  - `prefers-reduced-motion` → no hay animación: se revela el sitio al instante.
+  - Es fijo (fuera de flujo) → al desaparecer no hay layout shift.
+  - Decorativo para lectores de pantalla: el overlay no oculta el contenido real
+    (los adornos son aria-hidden; el botón de saltar mantiene su etiqueta).
+*/
+interface Props {
+  lang: 'es' | 'en' | string;
+}
+
+const { lang } = Astro.props;
+const isEs = lang !== 'en';
+
+const skipLabel = isEs ? 'saltar' : 'skip';
+const skipAria = isEs ? 'Saltar la secuencia de arranque' : 'Skip the boot sequence';
+
+// Líneas de arranque en la voz de FR-3D (el núcleo del sitio).
+const lines = isEs
+  ? [
+      'FR-3D CORE // hardcode labs',
+      '> montando sistema de archivos ......... ok',
+      '> cargando módulos de identidad ........ ok',
+      '> calibrando fósforo CRT ............... ok',
+      '> enlazando con freddy.exe ............. ok',
+      '> sistema listo. bienvenido.',
+    ]
+  : [
+      'FR-3D CORE // hardcode labs',
+      '> mounting filesystem ................. ok',
+      '> loading identity modules ............ ok',
+      '> calibrating CRT phosphor ............ ok',
+      '> linking with freddy.exe ............. ok',
+      '> system ready. welcome.',
+    ];
+---
+
+<div id="fr3d-boot" class="boot" data-boot hidden>
+  <div class="boot__screen">
+    <pre class="boot__log glow-amber" id="fr3d-boot-log" aria-hidden="true"></pre>
+    <div class="boot__meter" aria-hidden="true">
+      <div class="boot__bar" id="fr3d-boot-bar"></div>
+      <span class="boot__pct" id="fr3d-boot-pct">0%</span>
+    </div>
+  </div>
+  <button type="button" id="fr3d-boot-skip" class="boot__skip" aria-label={skipAria}>
+    {skipLabel} <span aria-hidden="true">&#9654;</span>
+  </button>
+</div>
+
+<script is:inline define:vars={{ lines }}>
+  // Decisión PRE-PAINT: este script es inline y síncrono en la posición del
+  // overlay, así que decide antes de pintar el resto del body (sin flash).
+  (function () {
+    var STORAGE_KEY = 'fr3d-boot-seen';
+    var el = document.getElementById('fr3d-boot');
+    if (!el) return;
+
+    var reduce = false;
+    try {
+      reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    } catch (_) {}
+
+    var seen = false;
+    try {
+      seen = localStorage.getItem(STORAGE_KEY) === '1';
+    } catch (_) {}
+
+    // Sin animación o ya visto: no mostramos el boot, se revela el sitio directo.
+    if (reduce || seen) return;
+
+    var markSeen = function () {
+      try { localStorage.setItem(STORAGE_KEY, '1'); } catch (_) {}
+    };
+
+    // Activar overlay (cubre el viewport antes de que pinte el contenido).
+    el.hidden = false;
+    el.classList.add('is-active');
+
+    var logEl = document.getElementById('fr3d-boot-log');
+    var barEl = document.getElementById('fr3d-boot-bar');
+    var pctEl = document.getElementById('fr3d-boot-pct');
+    var skipEl = document.getElementById('fr3d-boot-skip');
+
+    var finished = false;
+    var timers = [];
+
+    function clearTimers() {
+      for (var i = 0; i < timers.length; i++) clearTimeout(timers[i]);
+      timers = [];
+    }
+
+    function finish() {
+      if (finished) return;
+      finished = true;
+      clearTimers();
+      markSeen();
+      // Estado final visible un instante y fade-out.
+      if (barEl) barEl.style.width = '100%';
+      if (pctEl) pctEl.textContent = '100%';
+      el.classList.add('is-done');
+      document.removeEventListener('keydown', onKey, true);
+      window.setTimeout(function () {
+        el.hidden = true;
+        el.classList.remove('is-active', 'is-done');
+      }, 600);
+    }
+
+    function onKey(e) {
+      // Cualquier tecla salta (menos modificadores puros).
+      if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') return;
+      e.preventDefault();
+      finish();
+    }
+
+    if (skipEl) skipEl.addEventListener('click', function (e) { e.stopPropagation(); finish(); });
+    el.addEventListener('click', finish);
+    el.addEventListener('touchstart', finish, { passive: true });
+    document.addEventListener('keydown', onKey, true);
+
+    // Escritura de líneas + barra de progreso (~2.2s en total).
+    var total = lines.length;
+    var perLine = 300;
+    lines.forEach(function (line, i) {
+      timers.push(window.setTimeout(function () {
+        if (finished || !logEl) return;
+        logEl.textContent += (i === 0 ? '' : '\n') + line;
+        var pct = Math.round(((i + 1) / total) * 100);
+        if (barEl) barEl.style.width = pct + '%';
+        if (pctEl) pctEl.textContent = pct + '%';
+      }, i * perLine));
+    });
+
+    // Cierre automático tras la última línea.
+    timers.push(window.setTimeout(finish, total * perLine + 500));
+  })();
+</script>
+
+<style>
+  .boot {
+    position: fixed;
+    inset: 0;
+    z-index: 9000; /* sobre CRT (1000) y ship-fallback (5000); bajo modal móvil (9999) */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    background: var(--bg-field);
+    font-family: var(--font-terminal);
+    /* fade-out suave al terminar */
+    transition: opacity 0.55s ease, visibility 0s linear 0.55s;
+  }
+  /* Sin JS (o antes de activar) el overlay NO existe visualmente. */
+  .boot[hidden] {
+    display: none;
+  }
+  .boot.is-done {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  /* Scanlines + viñeta propias para reforzar el aire de terminal. */
+  .boot::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.04) 0 1px,
+        transparent 1px 3px
+      ),
+      radial-gradient(
+        ellipse at center,
+        transparent 55%,
+        color-mix(in srgb, var(--bg-field) 85%, transparent) 100%
+      );
+  }
+
+  .boot__screen {
+    position: relative;
+    z-index: 1;
+    width: min(90vw, 560px);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+  .boot__log {
+    margin: 0;
+    min-height: 8.5em;
+    font-family: var(--font-terminal);
+    font-size: clamp(1rem, 3.6vw, 1.35rem);
+    line-height: 1.35;
+    color: var(--amber-glow);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .boot__meter {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+  }
+  .boot__bar {
+    height: 0.7em;
+    width: 0%;
+    flex: 1;
+    background: var(--amber-glow);
+    box-shadow: 0 0 8px var(--amber-glow);
+    transition: width 0.28s ease;
+  }
+  .boot__meter {
+    border: 1px solid color-mix(in srgb, var(--amber-glow) 45%, transparent);
+    padding: 0.35em 0.5em;
+    border-radius: 3px;
+  }
+  .boot__pct {
+    font-size: clamp(0.95rem, 3vw, 1.2rem);
+    color: var(--amber-core);
+    min-width: 3.2em;
+    text-align: right;
+  }
+  .boot__skip {
+    position: relative;
+    z-index: 1;
+    font-family: var(--font-terminal);
+    font-size: clamp(1rem, 3.4vw, 1.25rem);
+    letter-spacing: 0.06em;
+    color: var(--red-core);
+    background: transparent;
+    border: 1px solid var(--red-core);
+    border-radius: 4px;
+    padding: 0.3em 1em;
+    cursor: pointer;
+    transition: 200ms;
+  }
+  .boot__skip:hover,
+  .boot__skip:focus-visible {
+    color: var(--cyan-core);
+    border-color: var(--cyan-glow);
+    box-shadow: 0 0 10px var(--cyan-glow);
+    background: color-mix(in srgb, var(--cyan-glow) 15%, transparent);
+    outline: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    /* Refuerzo defensivo: si el overlay llegara a mostrarse, sin transición. */
+    .boot { transition: none; }
+    .boot__bar { transition: none; }
+  }
+</style>

--- a/src/modules/portfolio/layout/components/CommandBar.astro
+++ b/src/modules/portfolio/layout/components/CommandBar.astro
@@ -1,0 +1,366 @@
+---
+/*
+  Paso 6 · Barra de comandos FR-3D — capa OPCIONAL de mejora progresiva.
+
+  - Sin JS no aparece (atributo `hidden`); el sitio navega con scroll/click/teclado.
+  - Cada comando tiene un equivalente visible en la interfaz (nav, footer, botones);
+    nada es exclusivo del comando.
+  - No captura el foco por defecto ni interfiere con el scroll. Se enfoca con `/`
+    o `` ` `` (o click) y se cierra con `Esc`. Sin focus trap.
+  - `help` siempre lista los comandos disponibles.
+*/
+interface Props {
+  lang: 'es' | 'en' | string;
+}
+
+const { lang } = Astro.props;
+const isEs = lang !== 'en';
+const BASE_URL = import.meta.env.BASE_URL;
+
+const inputAria = isEs
+  ? 'Barra de comandos opcional. Escribe help y pulsa Enter para ver los comandos.'
+  : 'Optional command bar. Type help and press Enter to list commands.';
+const placeholder = isEs
+  ? 'help · inicio · proyectos · cv · contacto…'
+  : 'help · home · projects · cv · contact…';
+const hint = isEs ? '/ enfocar · esc cerrar' : '/ focus · esc close';
+const label = isEs ? 'Consola' : 'Console';
+---
+
+<aside
+  id="fr3d-cmd"
+  class="cmdbar"
+  data-lang={isEs ? 'es' : 'en'}
+  data-base={BASE_URL}
+  aria-label={isEs ? 'Barra de comandos (opcional)' : 'Command bar (optional)'}
+  hidden
+>
+  <div class="cmdbar__log" id="fr3d-cmd-log" role="log" aria-live="polite"></div>
+  <form class="cmdbar__form" id="fr3d-cmd-form" autocomplete="off">
+    <label class="cmdbar__prompt" for="fr3d-cmd-input">
+      <span class="cmdbar__badge">{label}</span>
+      <span aria-hidden="true" class="glow-amber">FR-3D&nbsp;&gt;</span>
+    </label>
+    <input
+      id="fr3d-cmd-input"
+      class="cmdbar__input"
+      type="text"
+      name="cmd"
+      spellcheck="false"
+      autocapitalize="off"
+      autocorrect="off"
+      aria-label={inputAria}
+      placeholder={placeholder}
+    />
+    <span class="cmdbar__hint" aria-hidden="true">{hint}</span>
+  </form>
+</aside>
+
+<script>
+  interface CmdBarEl extends HTMLElement {}
+
+  const bar = document.getElementById('fr3d-cmd') as CmdBarEl | null;
+  if (bar) {
+    const lang = bar.dataset.lang === 'en' ? 'en' : 'es';
+    const base = bar.dataset.base || '';
+    const isEs = lang === 'es';
+    const form = document.getElementById('fr3d-cmd-form') as HTMLFormElement | null;
+    const input = document.getElementById('fr3d-cmd-input') as HTMLInputElement | null;
+    const log = document.getElementById('fr3d-cmd-log') as HTMLDivElement | null;
+
+    // Activar (mejora progresiva: solo con JS).
+    bar.hidden = false;
+
+    const t = (es: string, en: string) => (isEs ? es : en);
+
+    const print = (text: string, tone: 'out' | 'err' | 'echo' = 'out') => {
+      if (!log) return;
+      const line = document.createElement('div');
+      line.className = `cmdbar__line cmdbar__line--${tone}`;
+      line.textContent = text;
+      log.appendChild(line);
+      log.scrollTop = log.scrollHeight;
+    };
+
+    const clearLog = () => {
+      if (log) log.innerHTML = '';
+    };
+
+    // Navega a una sección: si está en la página actual, hace scroll suave;
+    // si no, navega a la home con el ancla (equivalente al nav visible).
+    const goSection = (id: string) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+        history.replaceState(null, '', `#${id}`);
+      } else {
+        window.location.href = `${base}/${lang}/#${id}`;
+      }
+    };
+
+    const goPage = (path: string) => {
+      window.location.href = `${base}/${lang}/${path}`;
+    };
+
+    type Command = {
+      run: () => void;
+      help: string;
+    };
+
+    const commands: Record<string, Command> = {
+      help: {
+        help: t('Lista los comandos disponibles', 'List available commands'),
+        run: () => {
+          print(t('Comandos disponibles:', 'Available commands:'), 'out');
+          Object.keys(commands)
+            .filter((k) => !ALIASES.has(k))
+            .forEach((k) => print(`  ${k.padEnd(18)} ${commands[k].help}`, 'out'));
+          print(
+            t(
+              'Todo esto también está en el menú, el footer y los botones.',
+              'All of this is also in the menu, footer and buttons.',
+            ),
+            'out',
+          );
+        },
+      },
+      inicio: {
+        help: t('Ir al inicio', 'Go to home'),
+        run: () => goSection('home'),
+      },
+      experiencia: {
+        help: t('Ir a experiencia', 'Go to experience'),
+        run: () => goSection('experience'),
+      },
+      proyectos: {
+        help: t('Ir a proyectos', 'Go to projects'),
+        run: () => goSection('projects'),
+      },
+      contacto: {
+        help: t('Ir a contacto', 'Go to contact'),
+        run: () => goSection('contact'),
+      },
+      cv: {
+        help: t('Abrir el CV', 'Open the CV'),
+        run: () => goPage('cv'),
+      },
+      'sistema-de-diseno': {
+        help: t('Abrir el sistema de diseño', 'Open the design system'),
+        run: () => goPage('design-system'),
+      },
+      idioma: {
+        help: t('Cambiar de idioma (es/en)', 'Switch language (es/en)'),
+        run: () => {
+          window.location.href = window.location.pathname.includes('/es/')
+            ? window.location.pathname.replace('/es/', '/en/')
+            : window.location.pathname.replace('/en/', '/es/');
+        },
+      },
+      whoami: {
+        help: t('¿Quién es FR-3D?', 'Who is FR-3D?'),
+        run: () =>
+          print(
+            t(
+              'FR-3D · núcleo de a bordo del portafolio de Freddy Tacuri.',
+              'FR-3D · onboard core of Freddy Tacuri’s portfolio.',
+            ),
+            'out',
+          ),
+      },
+      clear: {
+        help: t('Limpiar la consola', 'Clear the console'),
+        run: () => clearLog(),
+      },
+    };
+
+    // Alias en el idioma alterno + atajos (no se listan por separado en help).
+    const ALIAS_MAP: Record<string, string> = {
+      home: 'inicio',
+      start: 'inicio',
+      experience: 'experiencia',
+      projects: 'proyectos',
+      contact: 'contacto',
+      'design-system': 'sistema-de-diseno',
+      ds: 'sistema-de-diseno',
+      lang: 'idioma',
+      language: 'idioma',
+      ayuda: 'help',
+      about: 'inicio',
+      fr3d: 'whoami',
+      cls: 'clear',
+    };
+    const ALIASES = new Set(Object.keys(ALIAS_MAP));
+    Object.keys(ALIAS_MAP).forEach((alias) => {
+      commands[alias] = commands[ALIAS_MAP[alias]];
+    });
+
+    const runCommand = (raw: string) => {
+      const name = raw.trim().toLowerCase();
+      if (!name) return;
+      print(`FR-3D > ${name}`, 'echo');
+
+      // Easter eggs.
+      if (name === 'sudo' || name.startsWith('sudo ')) {
+        print(t('Permiso denegado: aquí mandas tú de otra forma :)', 'Permission denied: you already run this show :)'), 'err');
+        return;
+      }
+      if (name === 'help --easter' || name === 'konami') {
+        print('↑ ↑ ↓ ↓ ← → ← → B A', 'out');
+        return;
+      }
+
+      const cmd = commands[name];
+      if (cmd) {
+        cmd.run();
+      } else {
+        print(
+          t(
+            `Comando no reconocido: "${name}". Escribe help.`,
+            `Unknown command: "${name}". Type help.`,
+          ),
+          'err',
+        );
+      }
+    };
+
+    form?.addEventListener('submit', (e) => {
+      e.preventDefault();
+      if (!input) return;
+      runCommand(input.value);
+      input.value = '';
+    });
+
+    // `/` o `` ` `` enfocan la barra, salvo que ya se esté escribiendo en otro campo.
+    document.addEventListener('keydown', (e) => {
+      const active = document.activeElement as HTMLElement | null;
+      const typing =
+        active &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable);
+
+      if ((e.key === '/' || e.key === '`') && !typing) {
+        e.preventDefault();
+        input?.focus();
+      } else if (e.key === 'Escape' && active === input) {
+        input?.blur();
+      }
+    });
+  }
+</script>
+
+<style>
+  .cmdbar {
+    position: fixed;
+    left: 50%;
+    bottom: 0;
+    transform: translateX(-50%);
+    z-index: 900; /* sobre el nav (3); bajo CRT (1000) y modales */
+    width: min(96vw, 720px);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-terminal);
+    pointer-events: none; /* solo los hijos interactivos capturan eventos */
+  }
+  .cmdbar[hidden] {
+    display: none;
+  }
+
+  .cmdbar__log {
+    pointer-events: auto;
+    max-height: 32vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15em;
+    padding: 0 0.6em;
+    font-size: clamp(0.9rem, 2.6vw, 1.1rem);
+    line-height: 1.35;
+  }
+  .cmdbar__log:empty {
+    display: none;
+  }
+  .cmdbar__line {
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+    padding: 0.05em 0.4em;
+    border-radius: 2px;
+  }
+  .cmdbar__line--out {
+    color: var(--cyan-core);
+  }
+  .cmdbar__line--echo {
+    color: var(--amber-core);
+  }
+  .cmdbar__line--err {
+    color: var(--red-glow);
+    text-shadow: 0 0 6px color-mix(in srgb, var(--red-glow) 55%, transparent);
+  }
+
+  .cmdbar__form {
+    pointer-events: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.4em 0.7em;
+    background: color-mix(in srgb, var(--bg-base) 92%, transparent);
+    backdrop-filter: blur(6px);
+    border: 1px solid color-mix(in srgb, var(--amber-glow) 40%, transparent);
+    border-bottom: 0;
+    border-radius: 6px 6px 0 0;
+  }
+  .cmdbar__prompt {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    font-size: clamp(0.95rem, 2.8vw, 1.15rem);
+    white-space: nowrap;
+    cursor: text;
+  }
+  .cmdbar__badge {
+    font-family: var(--font-body);
+    font-size: 0.62em;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--red-core) 65%, transparent);
+    border: 1px solid color-mix(in srgb, var(--red-core) 35%, transparent);
+    padding: 0.15em 0.5em;
+    border-radius: 3px;
+  }
+  .cmdbar__input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    color: var(--amber-core);
+    font-family: var(--font-terminal);
+    font-size: clamp(1rem, 3vw, 1.25rem);
+    caret-color: var(--amber-glow);
+    outline: none;
+  }
+  .cmdbar__input::placeholder {
+    color: color-mix(in srgb, var(--red-core) 45%, transparent);
+  }
+  .cmdbar__input:focus-visible {
+    outline: none;
+  }
+  .cmdbar__form:focus-within {
+    border-color: var(--amber-glow);
+    box-shadow: 0 0 12px color-mix(in srgb, var(--amber-glow) 35%, transparent);
+  }
+  .cmdbar__hint {
+    font-family: var(--font-body);
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--red-core) 50%, transparent);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 560px) {
+    .cmdbar__badge,
+    .cmdbar__hint {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Resumen

Paso 6 — capa **aditiva de mejora progresiva** sobre el portafolio. El sitio ya funciona sin ella (scroll/click/teclado, sin JS); esta capa solo añade sabor terminal. Aquí VT323 toma su uso pleno. No se toca el sistema visual (color/fuentes/glow/CRT), el hero (paso 5) ni otras secciones.

Dos piezas nuevas, cableadas en `portfolio/layout/Layout.astro`:

### A) Boot FR-3D — `BootSequence.astro`
- Al cargar: pantalla negra → líneas de arranque en la voz de FR-3D (VT323, ámbar) → barra de progreso hasta 100% → revela el sitio.
- Corto (~2.3 s) y **saltable**: botón visible «saltar», cualquier tecla, click o toque.
- **Una sola vez** por navegador (`localStorage: fr3d-boot-seen`).
- `prefers-reduced-motion` → sin animación, se revela el sitio al instante.
- Es un **overlay fijo decorativo** sobre contenido que ya vive en el DOM; sin JS queda con `hidden` y nunca aparece. Sin layout shift al revelar (position: fixed). No es un gate: el contenido real no se bloquea ni se oculta a lectores de pantalla/crawlers.

### B) Barra de comandos — `CommandBar.astro`
- Consola opcional persistente abajo, con hint discreto. Se enfoca con `/` o `` ` `` y se cierra con `Esc`. **No captura el foco por defecto** ni interfiere con el scroll; **sin focus trap**.
- Comandos: `help` (siempre lista los disponibles), `inicio`, `experiencia`, `proyectos`, `contacto`, `cv`, `sistema-de-diseno`, `idioma`, `whoami`, `clear`, + alias bilingües (`home`, `projects`, `design-system`…) y espacio para easter eggs (`sudo`, `konami`).
- **Cada comando tiene equivalente visible** (menú, footer, botones): navegar a sección hace scroll suave si está en la página, o navega a la home con ancla si no. Nada es exclusivo del comando.
- Etiquetada (`<aside aria-label>`, input con `aria-label`, salida `role="log" aria-live="polite"`) y claramente opcional. Oculta sin JS.

## Verificación (Playwright + Chromium)
- `bun run build` pasa sin errores; `astro check` no reporta nada en los componentes nuevos (los 2 errores existentes son de `design-system.astro`/`ShipHero`, previos y fuera de alcance).
- **Mejora progresiva:** en el HTML estático ambos elementos salen con `hidden` → sin JS no hay boot ni barra, el sitio navega normal.
- Boot: corre una vez, no se repite tras recargar, saltable, e **instantáneo con `prefers-reduced-motion`** (verificado).
- Barra: no roba foco al cargar; `/` enfoca; `help` lista todo; comando desconocido muestra error; `Esc` libera el foco; `proyectos` hace scroll. Ambos idiomas.
- Sin errores de consola introducidos por esta capa (el `TypeError` de `classList` observado proviene del script previo de `NavBar`, no de este PR).

## GIFs
Adjunto en la sesión los GIFs del **boot** y de la **barra de comandos** (`boot.gif`, `cmdbar.gif`) para revisar; arrástralos aquí para dejarlos embebidos en el PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeYgK1CzkiRyZepNG3pWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdeYgK1CzkiRyZepNG3pWy)_