### PR TITLE
feat(terminal): motor de tareas asíncronas y comando `install` simulado

### DIFF
--- a/src/modules/terminal/commands/__demo.ts
+++ b/src/modules/terminal/commands/__demo.ts
@@ -1,0 +1,29 @@
+/*
+  Comando de humo (oculto) para ejercitar el motor de tareas contra la terminal
+  real: spinner, barra, y una línea de error anunciada. No aparece en `help` ni
+  en autocompletado. `install` (PASO/FASE 3) es el consumidor de verdad.
+*/
+
+import type { Command } from '../core/registry';
+import { ok, seg } from '../core/output';
+import { runTask } from '../tasks/runner';
+import type { TaskScript } from '../tasks/script';
+
+export const demo: Command = {
+  name: '__demo',
+  summary: { es: '', en: '' },
+  hidden: true,
+  run: async (_input, ctx) => {
+    const script: TaskScript = {
+      steps: [
+        { kind: 'print', line: [seg('DEMO iniciando motor de tareas', 'dim')] },
+        { kind: 'spinner', label: [seg('RESOLVE  resolviendo demo', 'accent')], ms: 500 },
+        { kind: 'progress', label: [seg('FETCH    descargando', 'data')], ms: 900 },
+        { kind: 'spinner', label: [seg('VERIFY   verificando integridad', 'accent')], ms: 400 },
+        { kind: 'fail', line: [seg('ERROR    demo: interrupción esperada', 'alert')] },
+      ],
+    };
+    await runTask(script, ctx.effects.task, ctx.effects.taskSignal());
+    return ok([]);
+  },
+};

--- a/src/modules/terminal/commands/index.ts
+++ b/src/modules/terminal/commands/index.ts
@@ -6,6 +6,7 @@ import type { Command } from '../core/registry';
 import { clear, echo, fullscreen, help, history, konami, sudo, whoami } from './system';
 import { cat, cd, ls, pwd, tree } from './fs';
 import { lang, open } from './open';
+import { install } from './install';
 import { demo } from './__demo';
 
 export const COMMANDS: Command[] = [
@@ -22,6 +23,8 @@ export const COMMANDS: Command[] = [
   open,
   lang,
   fullscreen,
+  // Comando simulado (hidden).
+  install,
   // Easter eggs (hidden).
   sudo,
   konami,

--- a/src/modules/terminal/commands/index.ts
+++ b/src/modules/terminal/commands/index.ts
@@ -6,6 +6,7 @@ import type { Command } from '../core/registry';
 import { clear, echo, fullscreen, help, history, konami, sudo, whoami } from './system';
 import { cat, cd, ls, pwd, tree } from './fs';
 import { lang, open } from './open';
+import { demo } from './__demo';
 
 export const COMMANDS: Command[] = [
   help,
@@ -24,4 +25,6 @@ export const COMMANDS: Command[] = [
   // Easter eggs (hidden).
   sudo,
   konami,
+  // Comando de humo del motor de tareas (hidden).
+  demo,
 ];

--- a/src/modules/terminal/commands/install.ts
+++ b/src/modules/terminal/commands/install.ts
@@ -1,0 +1,153 @@
+/*
+  `install` simulado. Es la excusa del motor de tareas: anima fases con el
+  lenguaje visual de la terminal (etiquetas en mayúsculas, barras ASCII, sin
+  emoji) y termina en un error rotativo o, si el paquete ya está a bordo, en un
+  "ya está instalado". NO imita la salida literal de bun: eso chocaría con el CRT.
+
+  Oculto (`hidden`): el chiste es mejor encontrado que ofrecido. Alias de gestor
+  (bun/npm/pnpm/yarn) que aceptan su subcomando de instalación.
+
+  El comando escribe por el sink (salida progresiva), así que devuelve `ok()` SIN
+  líneas: si devolviera contenido, renderResult lo pintaría otra vez tras animar.
+*/
+
+import type { Command } from '../core/registry';
+import type { Lang } from '../core/i18n';
+import type { Line, Tone } from '../core/output';
+import type { TaskScript } from '../tasks/script';
+import type { KnownPackage } from '../constants/INSTALL';
+import { fail, ok, seg } from '../core/output';
+import { t } from '../core/i18n';
+import { runTask } from '../tasks/runner';
+import { createBag } from '../tasks/random';
+import {
+  ALREADY_INSTALLED,
+  INSTALL_ERRORS,
+  INSTALL_PHASES,
+  INSTALL_USAGE,
+  KNOWN_PACKAGES,
+} from '../constants/INSTALL';
+
+const MAX_PACKAGES = 5;
+const MAX_NAME_LEN = 64;
+const LABEL_WIDTH = 9;
+
+/** Subcomandos de instalación que aceptan los alias (bun add, npm i, …). */
+const INSTALL_SUBCOMMANDS = new Set(['install', 'add', 'i']);
+
+/**
+ * Bolsa de errores a nivel de módulo: persiste entre invocaciones para no
+ * repetir el mismo error dos veces seguidas dentro de una sesión.
+ */
+const nextError = createBag(INSTALL_ERRORS);
+
+/** Saneado del nombre que se hace eco en pantalla: sin control chars, ≤64. */
+const sanitize = (raw: string): string =>
+  raw.replace(/[\u0000-\u001F\u007F]/g, '').slice(0, MAX_NAME_LEN);
+
+/** Línea de fase: etiqueta en mayúsculas (ancho fijo) + descripción. */
+const phaseLine = (label: string, desc: string, labelTone: Tone): Line => [
+  seg(label.padEnd(LABEL_WIDTH), labelTone),
+  seg(desc, 'default'),
+];
+
+type PkgClass =
+  | { kind: 'installed'; pkg: string }
+  | { kind: 'known'; pkg: string; known: KnownPackage }
+  | { kind: 'unknown'; pkg: string };
+
+const classify = (pkg: string, installed: Set<string>): PkgClass => {
+  const lower = pkg.toLowerCase();
+  if (installed.has(lower)) return { kind: 'installed', pkg };
+  const known = KNOWN_PACKAGES.find((k) => k.names.includes(lower));
+  if (known) return { kind: 'known', pkg, known };
+  return { kind: 'unknown', pkg };
+};
+
+const usageResult = (lang: Lang) => ok([[seg(t(INSTALL_USAGE, lang), 'dim')]]);
+
+export const install: Command = {
+  name: 'install',
+  summary: { es: '', en: '' },
+  usage: INSTALL_USAGE,
+  aliases: ['bun', 'npm', 'pnpm', 'yarn'],
+  hidden: true,
+  run: async (input, ctx) => {
+    const lang = ctx.lang;
+
+    // 1) Resolver el subcomando cuando se invoca por alias (bun/npm/…).
+    let args = input.args;
+    if (input.name !== 'install') {
+      const sub = args[0];
+      // `bun` a secas → uso, como el binario real.
+      if (sub === undefined) return usageResult(lang);
+      // `bun run`, `npm test` → error normal, sin animación.
+      if (!INSTALL_SUBCOMMANDS.has(sub.toLowerCase())) {
+        return fail(
+          t(
+            {
+              es: `${input.name}: subcomando no soportado: ${sanitize(sub)}`,
+              en: `${input.name}: unsupported subcommand: ${sanitize(sub)}`,
+            },
+            lang,
+          ),
+        );
+      }
+      args = args.slice(1);
+    }
+
+    // 2) Sanear y limitar la lista de paquetes.
+    const packages = args
+      .map(sanitize)
+      .filter((p) => p.length > 0)
+      .slice(0, MAX_PACKAGES);
+    if (packages.length === 0) return usageResult(lang);
+
+    // 3) Clasificar contra el árbol real y los paquetes con nombre propio.
+    const installed = new Set(ctx.packages.map((p) => p.toLowerCase()));
+    const classes = packages.map((p) => classify(p, installed));
+    const anyUnknown = classes.some((c) => c.kind === 'unknown');
+
+    const sink = ctx.effects.task;
+    const signal = ctx.effects.taskSignal();
+    const subject = packages.join(', ');
+
+    if (anyUnknown) {
+      // Animación completa → error de la bolsa → guiño. Presupuesto ~2.4s.
+      const err = nextError();
+      const script: TaskScript = {
+        steps: [
+          { kind: 'spinner', label: phaseLine('RESOLVE', `${t(INSTALL_PHASES.resolve, lang)} ${subject}`, 'data'), ms: 500 },
+          { kind: 'progress', label: phaseLine('FETCH', t(INSTALL_PHASES.fetch, lang), 'data'), ms: 900 },
+          { kind: 'spinner', label: phaseLine('VERIFY', t(INSTALL_PHASES.verify, lang), 'data'), ms: 400 },
+          { kind: 'progress', label: phaseLine('LINK', t(INSTALL_PHASES.link, lang), 'data'), ms: 600 },
+          { kind: 'fail', line: phaseLine('ERROR', `${err.code}: ${t(err.message, lang)}`, 'alert') },
+        ],
+      };
+      await runTask(script, sink, signal);
+      // El guiño va DESPUÉS del `fail` (que termina la tarea) y solo si no se
+      // abortó. No anunciado: la única línea anunciada es el error.
+      if (!signal.aborted) sink.write([seg(t(err.wink, lang), 'accent')], false);
+      return ok([]);
+    }
+
+    // Todos conocidos/instalados → animación corta → respuesta(s), sin error.
+    const script: TaskScript = {
+      steps: [
+        { kind: 'spinner', label: phaseLine('RESOLVE', `${t(INSTALL_PHASES.resolve, lang)} ${subject}`, 'data'), ms: 400 },
+        { kind: 'progress', label: phaseLine('LINK', t(INSTALL_PHASES.link, lang), 'data'), ms: 350 },
+      ],
+    };
+    await runTask(script, sink, signal);
+    if (!signal.aborted) {
+      let announced = false;
+      for (const c of classes) {
+        const resp = c.kind === 'known' ? c.known.response : ALREADY_INSTALLED(c.pkg);
+        // Anuncia solo la primera línea de resultado; el resto va silenciado.
+        sink.write([seg(t(resp, lang), 'ok')], !announced);
+        announced = true;
+      }
+    }
+    return ok([]);
+  },
+};

--- a/src/modules/terminal/commands/system.ts
+++ b/src/modules/terminal/commands/system.ts
@@ -43,6 +43,20 @@ export const help: Command = {
         'dim',
       ),
     );
+    // Guiño: algunos comandos no salen en esta lista (hidden). Se insinúa sin
+    // nombrarlos — el mérito del hallazgo es de quien explora.
+    lines.push(
+      line(
+        t(
+          {
+            es: '…y algún que otro comando no aparece en esta lista.',
+            en: '…and the odd command does not show up in this list.',
+          },
+          ctx.lang,
+        ),
+        'dim',
+      ),
+    );
     return ok(lines);
   },
 };

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -26,8 +26,17 @@
   maestro completo.
 */
 import resume from "../../../constants/resume.json";
+import pkg from "../../../../package.json";
 import { separateLanguages } from "../../../shared/utils/languageSeparator";
 import { buildTree } from "../fs/build";
+
+// Nombres de las dependencias REALES del proyecto, extraídos en build time para
+// que `install <dep>` responda "ya está instalado". Solo viajan los nombres al
+// cliente, nunca el package.json entero.
+const installPackages = [
+	...Object.keys((pkg as { dependencies?: Record<string, string> }).dependencies ?? {}),
+	...Object.keys((pkg as { devDependencies?: Record<string, string> }).devDependencies ?? {}),
+];
 
 interface Props {
 	lang: "es" | "en" | string;
@@ -53,6 +62,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 	class="cmdbar"
 	data-lang={isEs ? "es" : "en"}
 	data-base={BASE_URL}
+	data-packages={JSON.stringify(installPackages)}
 	aria-label={isEs ? "Barra de comandos (opcional)" : "Command bar (optional)"}
 	hidden>
 	<div class="cmdbar__shell" id="fr3d-shell">
@@ -147,6 +157,12 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 	) {
 		const lang = (bar.dataset.lang === "en" ? "en" : "es") as "es" | "en";
 		const base = bar.dataset.base || "";
+		// Nombres de dependencias reales (build time) para el comando `install`.
+		let packages: string[] = [];
+		try {
+			const parsed = JSON.parse(bar.dataset.packages || "[]");
+			if (Array.isArray(parsed)) packages = parsed.filter((p) => typeof p === "string");
+		} catch {}
 
 		// Mejora progresiva: la barra solo aparece con JS.
 		bar.hidden = false;
@@ -327,7 +343,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			taskSignal: () => (taskController ??= new AbortController()).signal,
 		};
 
-		const ctx: ShellContext = { state, fs, registry, lang, effects };
+		const ctx: ShellContext = { state, fs, registry, lang, effects, packages };
 
 		// Estado de ergonomía de shell (historial, autocompletado).
 		let historyIndex = state.history.length; // índice en state.history; length = borrador

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -167,6 +167,32 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		// Mejora progresiva: la barra solo aparece con JS.
 		bar.hidden = false;
 
+		// Guiño para quien abre la consola del navegador (devs, reclutadores
+		// técnicos): FR-3D saluda y planta un hilo del que tirar, sin listar los
+		// comandos ocultos — el mérito del hallazgo sigue siendo del visitante.
+		// Guardado en window para no repetirlo si el script corriera dos veces.
+		const w = window as typeof window & { __fr3dMotd?: boolean };
+		if (!w.__fr3dMotd) {
+			w.__fr3dMotd = true;
+			const [headline, tip] =
+				lang === "es"
+					? [
+							"Núcleo de a bordo en línea.",
+							"No todo lo que sé cabe en `help`. Los curiosos prueban a instalar algo.",
+						]
+					: [
+							"Onboard core online.",
+							"Not everything I know fits in `help`. The curious try installing something.",
+						];
+			const mono =
+				"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;";
+			console.log(
+				`%cFR-3D>%c ${headline}\n       ${tip}`,
+				`color:#FFB000;font-weight:700;${mono}`,
+				`color:#FFB000;line-height:1.7;${mono}`,
+			);
+		}
+
 		const fs = JSON.parse(vfsTag.textContent || "{}") as DirNode;
 		const state = createState(lang);
 		const registry = new Registry();

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -322,6 +322,10 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			scrollToBottom();
 		};
 
+		// Cambio de página a mitad de tarea: abortar para no dejar temporizadores
+		// huérfanos (pagehide cubre también las view transitions de Astro).
+		window.addEventListener("pagehide", () => taskController?.abort());
+
 		const effects: ShellEffects = {
 			clear: () => logEl.replaceChildren(),
 			open: (url) => {
@@ -457,10 +461,12 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			const wasFocused = document.activeElement === input;
 			const result = await execute(raw, ctx);
 			if (result) renderResult(result);
-			// Si el usuario seguía en el input tras una tarea, devuélvele el foco (el
-			// input `disabled` lo pierde); si se fue a otro sitio, no se lo robamos.
-			if (wasFocused && !input.disabled && document.activeElement !== input) {
-				input.focus();
+			// Foco tras una tarea: al deshabilitar el input durante la animación el
+			// foco cae en <body>. Se lo devolvemos solo si sigue evaporado ahí (fue
+			// cosa nuestra); si el usuario se fue a otro elemento, no se lo robamos.
+			if (wasFocused && !input.disabled) {
+				const ae = document.activeElement;
+				if (!ae || ae === document.body) input.focus();
 			}
 			historyIndex = state.history.length; // ↑ arranca desde el más reciente
 			draft = "";

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -10,6 +10,11 @@
     easter eggs) es exclusivo.
   - No captura el foco por defecto ni interfiere con el scroll. Se enfoca con `/`
     o `` ` `` (o click) y se sale con `Esc`. Sin focus trap.
+  - Jerarquía de `Esc` (3 niveles): tarea en curso → aborta la tarea; pantalla
+    completa → vuelve a acoplado; acoplado y enfocado → desenfoca el input.
+  - Tareas asíncronas (comandos con salida progresiva, p. ej. `install`): corren
+    contra un TerminalSink que reescribe líneas en vivo. Mientras una corre, el
+    input queda `disabled` (una tarea a la vez) y Ctrl+C / Esc la abortan.
   - EXCEPCIÓN — pantalla completa (Ctrl+` o comando `fullscreen`): la terminal
     cubre el viewport y SÍ se comporta como modal (<dialog> + showModal: role
     dialog, aria-modal, focus trap, foco devuelto al salir). Es la conducta
@@ -103,6 +108,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 	import { createState } from "../core/state";
 	import { Registry } from "../core/registry";
 	import type { ShellContext, ShellEffects } from "../core/registry";
+	import type { TerminalSink, LineHandle } from "../core/sink";
 	import { execute } from "../core/execute";
 	import { COMMANDS } from "../commands";
 	import { buildPrompt } from "../constants/PROMPT";
@@ -236,8 +242,69 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		// en vez de cerrar del todo (mismo patrón que ExperienceDetail.astro).
 		dialog.addEventListener("cancel", (e) => {
 			e.preventDefault();
+			// Jerarquía de Esc: una tarea en curso se aborta antes que salir de
+			// pantalla completa.
+			if (taskRunning) {
+				abortTask();
+				return;
+			}
 			exitFullscreen();
 		});
+
+		/* ----- Motor de tareas: sink, estado ocupado y cancelación --------- */
+
+		// Placeholder original del input (localizado en el frontmatter), para
+		// restaurarlo al salir del estado ocupado.
+		const defaultPlaceholder = input.placeholder;
+
+		// Una tarea a la vez. La terminal es dueña del AbortController; se renueva
+		// por comando (ver submit) y lo abortan Ctrl+C / Esc. `taskRunning` refleja
+		// busy() y decide si Ctrl+C aborta una tarea o solo limpia el input.
+		let taskController: AbortController | null = null;
+		let taskRunning = false;
+
+		// Bloquea/libera el input mientras corre una tarea. Las teclas pulsadas
+		// durante la ejecución se descartan (input disabled), no se encolan.
+		const setBusy = (running: boolean) => {
+			taskRunning = running;
+			input.disabled = running;
+			shell.setAttribute("aria-busy", running ? "true" : "false");
+			form.dataset.busy = running ? "true" : "false";
+			if (running) {
+				input.value = "";
+				input.placeholder = lang === "es" ? "trabajando…" : "working…";
+			} else {
+				input.placeholder = defaultPlaceholder;
+			}
+		};
+
+		// El sink que consume el runner: reutiliza appendLine/fillSegments. El
+		// handle de una línea es el <div> que appendLine devuelve; sobrevive al
+		// movimiento del shell entre acoplado y <dialog> (es una referencia a nodo).
+		const taskSink: TerminalSink = {
+			write: (lineData, announce = false) => {
+				const el = appendLine(lineData, !announce);
+				scrollToBottom();
+				return el as LineHandle;
+			},
+			// Siempre vía fillSegments: reasignar textContent dejaría la línea sin
+			// tono (el color es inline) y saldría en --red-core sin avisar.
+			update: (handle, lineData) => fillSegments(handle as HTMLElement, lineData),
+			busy: (running) => setBusy(running),
+			reducedMotion: () =>
+				window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+		};
+
+		// Aborta la tarea en curso y deja rastro (^C), como la interrupción normal.
+		// El runner libera el input en su `finally` poco después.
+		const abortTask = () => {
+			if (!taskRunning || !taskController) return;
+			taskController.abort();
+			const [top, bot] = buildPrompt(state);
+			appendLine(top, true);
+			appendLine([...bot, { text: " ^C", tone: "dim" }], true);
+			scrollToBottom();
+		};
 
 		const effects: ShellEffects = {
 			clear: () => logEl.replaceChildren(),
@@ -255,6 +322,9 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 					: path.replace("/en/", "/es/");
 			},
 			toggleFullscreen: () => toggleFullscreen(),
+			task: taskSink,
+			// La señal se renueva por comando en el submit; lazy por seguridad.
+			taskSignal: () => (taskController ??= new AbortController()).signal,
 		};
 
 		const ctx: ShellContext = { state, fs, registry, lang, effects };
@@ -321,7 +391,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		// a11y: el log es aria-live="polite". Para no leer 20 líneas de `tree`,
 		// el eco y todo salvo la primera línea útil del resultado van aria-hidden;
 		// así solo se anuncia esa primera línea (constraint #4: el log sigue polite).
-		const appendLine = (lineData: Line, ariaHidden = false) => {
+		const appendLine = (lineData: Line, ariaHidden = false): HTMLDivElement => {
 			const div = document.createElement("div");
 			div.className = "cmdbar__line";
 			div.style.whiteSpace = "pre-wrap";
@@ -329,6 +399,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			if (ariaHidden) div.setAttribute("aria-hidden", "true");
 			fillSegments(div, lineData);
 			logEl.appendChild(div);
+			return div;
 		};
 
 		// Prompt de la barra: se construye desde state y se re-renderiza tras cada
@@ -364,8 +435,17 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			if (!raw.trim()) return;
 			const prompt = buildPrompt(state); // prompt activo (cwd previo al comando)
 			echoCommand(raw, prompt);
+			// Señal fresca por comando: si el comando lanza una tarea, Ctrl+C / Esc
+			// abortan ESTA ejecución. Los comandos síncronos la ignoran.
+			taskController = new AbortController();
+			const wasFocused = document.activeElement === input;
 			const result = await execute(raw, ctx);
 			if (result) renderResult(result);
+			// Si el usuario seguía en el input tras una tarea, devuélvele el foco (el
+			// input `disabled` lo pierde); si se fue a otro sitio, no se lo robamos.
+			if (wasFocused && !input.disabled && document.activeElement !== input) {
+				input.focus();
+			}
 			historyIndex = state.history.length; // ↑ arranca desde el más reciente
 			draft = "";
 			tabStuck = false;
@@ -543,6 +623,22 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 					active.tagName === "TEXTAREA" ||
 					active.isContentEditable);
 
+			// Tarea en curso: el input está disabled, así que su propio manejador de
+			// Ctrl+C no dispara; se atienden aquí. Esc en pantalla completa lo cubre
+			// el `cancel` del dialog. Ctrl+` (pantalla completa) sigue permitido.
+			if (taskRunning) {
+				if (e.ctrlKey && (e.key === "c" || e.key === "C")) {
+					e.preventDefault();
+					abortTask();
+					return;
+				}
+				if (e.key === "Escape" && !isFullscreen) {
+					e.preventDefault();
+					abortTask();
+					return;
+				}
+			}
+
 			if (e.ctrlKey && e.key === "`") {
 				e.preventDefault();
 				toggleFullscreen();
@@ -641,9 +737,19 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 	}
 	/* En pantalla completa el input siempre visible (el foco queda atrapado en el
      dialog, y aunque se clique un enlace del log no debe plegarse). */
-	.cmdbar-dialog .cmdbar__prompt-line {
+	.cmdbar-dialog .cmdbar__prompt-line,
+	/* Mientras corre una tarea el input está disabled (no puede tener foco), pero
+     se despliega igual para mostrar el estado "trabajando…". */
+	.cmdbar__form[data-busy="true"] .cmdbar__prompt-line {
 		max-height: 3em;
 		opacity: 1;
+	}
+	.cmdbar__form[data-busy="true"] .cmdbar__prompt {
+		opacity: 0.6;
+	}
+	.cmdbar__input:disabled {
+		cursor: progress;
+		opacity: 0.7;
 	}
 	.cmdbar__prompt {
 		display: flex;

--- a/src/modules/terminal/constants/INSTALL.ts
+++ b/src/modules/terminal/constants/INSTALL.ts
@@ -1,12 +1,12 @@
 /*
   Contenido de `install`: frases de fase, errores rotativos y respuestas de
-  paquetes conocidos. Todo bilingüe (I18nText). Regla que gobierna el contenido:
-  realista en la FORMA, imposible de confundir con un fallo real en el FONDO —
-  cada error va seguido de un guiño de FR-3D que deja claro que es intencional
-  sin explicar el chiste.
+  paquetes conocidos. Todo bilingüe (I18nText).
 
-  NOTA: PASO/FASE 4 amplía este archivo a los 5 errores (5 ejes distintos) y a
-  las respuestas de paquetes con nombre propio. Aquí va la base funcional.
+  Regla que gobierna todo el contenido: realista en la FORMA, imposible de
+  confundir con un fallo real en el FONDO. La línea de error imita un error de
+  verdad (código, sujeto, causa); la línea inmediatamente posterior de FR-3D
+  deja claro que es intencional SIN explicar el chiste. El guiño va en personaje
+  (nave, sandbox, sistema HLCS), nunca metahumor tipo "jaja es broma".
 */
 
 import type { I18nText } from '../core/i18n';
@@ -41,7 +41,12 @@ export interface InstallError {
   wink: I18nText;
 }
 
-// Base funcional (2 ejes). FASE 4 completa a 5 ejes distintos.
+// Cinco ejes distintos para que no se parezcan entre sí:
+// 1 ENOTFOUND  — el sandbox no tiene salida a la red
+// 2 EACCES     — sistema de archivos de solo lectura
+// 3 ENOSPC     — sin espacio en el volumen
+// 4 EINTEGRITY — suma de verificación que no coincide
+// 5 ETIMEDOUT  — el registro no respondió
 export const INSTALL_ERRORS: InstallError[] = [
   {
     code: 'ENOTFOUND',
@@ -51,7 +56,40 @@ export const INSTALL_ERRORS: InstallError[] = [
     },
     wink: {
       es: 'FR-3D> A bordo no hay antena hacia npm. Aquí todo llega ya cargado.',
-      en: 'FR-3D> No antenna to npm on board. Up here everything ships preloaded.',
+      en: 'FR-3D> No antenna to npm on board. Everything up here ships preloaded.',
+    },
+  },
+  {
+    code: 'EACCES',
+    message: {
+      es: 'permiso denegado al escribir en node_modules: montado en solo lectura',
+      en: 'permission denied writing to node_modules: mounted read-only',
+    },
+    wink: {
+      es: 'FR-3D> El casco de la HLCS va sellado. Nada nuevo se atornilla en pleno vuelo.',
+      en: 'FR-3D> The HLCS hull is sealed. Nothing new gets bolted on mid-flight.',
+    },
+  },
+  {
+    code: 'ENOSPC',
+    message: {
+      es: 'no queda espacio en el dispositivo: volumen /hlcs al 100%',
+      en: 'no space left on device: volume /hlcs at 100%',
+    },
+    wink: {
+      es: 'FR-3D> Las bodegas van llenas de portafolio. No cabe una dependencia más.',
+      en: 'FR-3D> The holds are packed with portfolio. Not one more dependency fits.',
+    },
+  },
+  {
+    code: 'EINTEGRITY',
+    message: {
+      es: 'fallo de integridad: la suma de verificación del paquete no coincide',
+      en: 'integrity check failed: package checksum does not match',
+    },
+    wink: {
+      es: 'FR-3D> Ese paquete no pasa el control de la esclusa. Procedencia sin confirmar.',
+      en: 'FR-3D> That package fails the airlock check. Provenance unconfirmed.',
     },
   },
   {
@@ -62,18 +100,62 @@ export const INSTALL_ERRORS: InstallError[] = [
     },
     wink: {
       es: 'FR-3D> El registro está a varios años luz. La HLCS no espera tanto.',
-      en: 'FR-3D> The registry is light-years out. The HLCS does not wait that long.',
+      en: "FR-3D> The registry is light-years out. The HLCS doesn't wait that long.",
     },
   },
 ];
 
 /**
- * Paquete con respuesta propia (react/vue/…, y un guiño único como `fr3d`). Se
- * empareja por nombre en minúsculas. FASE 4 rellena esta lista.
+ * Paquete con respuesta propia. Se empareja por nombre en minúsculas. Cubre a
+ * quien teclea `install react` en un sitio hecho con Astro, más un guiño único
+ * para `fr3d` / `hardcode-labs`.
  */
 export interface KnownPackage {
   names: string[];
   response: I18nText;
 }
 
-export const KNOWN_PACKAGES: KnownPackage[] = [];
+export const KNOWN_PACKAGES: KnownPackage[] = [
+  {
+    names: ['react', 'react-dom'],
+    response: {
+      es: 'react — este sitio corre sobre Astro; las islas van sin framework. Buen intento.',
+      en: 'react — this site runs on Astro; the islands ship frameworkless. Nice try.',
+    },
+  },
+  {
+    names: ['vue'],
+    response: {
+      es: 'vue — bonito framework, pero aquí el render es HTML plano de Astro.',
+      en: 'vue — lovely framework, but here the render is plain Astro HTML.',
+    },
+  },
+  {
+    names: ['svelte'],
+    response: {
+      es: 'svelte — compilar a casi nada es elegante; Astro ya envía casi nada.',
+      en: 'svelte — compiling to almost nothing is elegant; Astro already ships almost nothing.',
+    },
+  },
+  {
+    names: ['next', 'nextjs'],
+    response: {
+      es: 'next — el SSR aquí lo hace Astro. No hace falta traer todo Next a bordo.',
+      en: 'next — Astro handles the SSR here. No need to bring all of Next aboard.',
+    },
+  },
+  {
+    names: ['tailwind', 'tailwindcss'],
+    response: {
+      es: 'tailwind — los estilos van con tokens propios y CSS scopeado. Sin utilidades.',
+      en: 'tailwind — styling uses in-house tokens and scoped CSS. No utility classes.',
+    },
+  },
+  {
+    names: ['fr3d', 'fr-3d', 'hardcode-labs', 'hardcodelabs'],
+    response: {
+      es: 'fr3d ya está a bordo — soy yo. No puedo instalarme dos veces.',
+      en: "fr3d is already aboard — that's me. I can't install myself twice.",
+    },
+  },
+];

--- a/src/modules/terminal/constants/INSTALL.ts
+++ b/src/modules/terminal/constants/INSTALL.ts
@@ -1,0 +1,79 @@
+/*
+  Contenido de `install`: frases de fase, errores rotativos y respuestas de
+  paquetes conocidos. Todo bilingüe (I18nText). Regla que gobierna el contenido:
+  realista en la FORMA, imposible de confundir con un fallo real en el FONDO —
+  cada error va seguido de un guiño de FR-3D que deja claro que es intencional
+  sin explicar el chiste.
+
+  NOTA: PASO/FASE 4 amplía este archivo a los 5 errores (5 ejes distintos) y a
+  las respuestas de paquetes con nombre propio. Aquí va la base funcional.
+*/
+
+import type { I18nText } from '../core/i18n';
+
+/** Etiquetas de fase (mayúsculas) + su descripción, con el lenguaje de la HLCS. */
+export const INSTALL_PHASES = {
+  resolve: { es: 'resolviendo', en: 'resolving' } as I18nText,
+  fetch: { es: 'descargando desde el registro', en: 'downloading from registry' } as I18nText,
+  verify: { es: 'verificando integridad', en: 'verifying integrity' } as I18nText,
+  link: { es: 'enlazando dependencias', en: 'linking dependencies' } as I18nText,
+};
+
+/** Uso del comando, mostrado sin animación cuando falta el paquete. */
+export const INSTALL_USAGE: I18nText = {
+  es: 'uso: install <paquete> · alias: bun / npm / pnpm / yarn add <paquete>',
+  en: 'usage: install <package> · aliases: bun / npm / pnpm / yarn add <package>',
+};
+
+/** Respuesta cuando el paquete ya está en el árbol real del proyecto. */
+export const ALREADY_INSTALLED = (pkg: string): I18nText => ({
+  es: `${pkg} ya está instalado — esta nave ya lo lleva a bordo.`,
+  en: `${pkg} is already installed — this ship already carries it.`,
+});
+
+/**
+ * Un error imita la forma de un fallo real (código, sujeto, causa); el `wink`
+ * inmediatamente posterior, en personaje, aclara que es a propósito.
+ */
+export interface InstallError {
+  code: string;
+  message: I18nText;
+  wink: I18nText;
+}
+
+// Base funcional (2 ejes). FASE 4 completa a 5 ejes distintos.
+export const INSTALL_ERRORS: InstallError[] = [
+  {
+    code: 'ENOTFOUND',
+    message: {
+      es: 'no se pudo resolver el registro: el sandbox no tiene salida a la red',
+      en: 'could not resolve registry: the sandbox has no network egress',
+    },
+    wink: {
+      es: 'FR-3D> A bordo no hay antena hacia npm. Aquí todo llega ya cargado.',
+      en: 'FR-3D> No antenna to npm on board. Up here everything ships preloaded.',
+    },
+  },
+  {
+    code: 'ETIMEDOUT',
+    message: {
+      es: 'tiempo de espera agotado: el registro no respondió',
+      en: 'request timed out: the registry did not respond',
+    },
+    wink: {
+      es: 'FR-3D> El registro está a varios años luz. La HLCS no espera tanto.',
+      en: 'FR-3D> The registry is light-years out. The HLCS does not wait that long.',
+    },
+  },
+];
+
+/**
+ * Paquete con respuesta propia (react/vue/…, y un guiño único como `fr3d`). Se
+ * empareja por nombre en minúsculas. FASE 4 rellena esta lista.
+ */
+export interface KnownPackage {
+  names: string[];
+  response: I18nText;
+}
+
+export const KNOWN_PACKAGES: KnownPackage[] = [];

--- a/src/modules/terminal/core/registry.ts
+++ b/src/modules/terminal/core/registry.ts
@@ -8,6 +8,7 @@ import type { ShellState } from './state';
 import type { I18nText, Lang } from './i18n';
 import type { CommandResult } from './output';
 import type { ParsedCommand } from './parser';
+import type { TerminalSink } from './sink';
 import type { DirNode } from '../fs/types';
 
 /** Efectos de UI que un comando puede pedir; los implementa Terminal.astro. */
@@ -20,6 +21,17 @@ export interface ShellEffects {
   toggleLang(): void;
   /** Alterna entre barra acoplada y pantalla completa (comando `fullscreen`). */
   toggleFullscreen(): void;
+  /**
+   * Sink de salida progresiva: un comando animado escribe por aquí (vía
+   * `runTask`) en vez de devolver líneas. La terminal lo implementa reutilizando
+   * `appendLine`/`fillSegments`.
+   */
+  task: TerminalSink;
+  /**
+   * Señal de la tarea en curso, para pasarla a `runTask`. La terminal es dueña
+   * del `AbortController`; Ctrl+C y Esc lo abortan. Se renueva por comando.
+   */
+  taskSignal(): AbortSignal;
 }
 
 export interface ShellContext {

--- a/src/modules/terminal/core/registry.ts
+++ b/src/modules/terminal/core/registry.ts
@@ -40,6 +40,12 @@ export interface ShellContext {
   registry: Registry;
   lang: Lang;
   effects: ShellEffects;
+  /**
+   * Nombres de las dependencias reales del proyecto, extraídos de package.json
+   * en build time (ver Terminal.astro). Los consume `install` para responder
+   * "ya está instalado" a un paquete que de verdad está en el árbol.
+   */
+  packages: string[];
 }
 
 export interface Command {

--- a/src/modules/terminal/core/sink.ts
+++ b/src/modules/terminal/core/sink.ts
@@ -1,0 +1,32 @@
+/*
+  Puerto entre el motor de tareas (`tasks/`) y la terminal. La dependencia va
+  SIEMPRE tarea → terminal: el motor habla con esta interfaz y nunca con el DOM.
+  Lo implementa Terminal.astro (ver PASO/FASE 2) reutilizando `appendLine` y
+  `fillSegments`; en tests se implementa con un doble de mentira.
+
+  Reutiliza `Line`/`Tone` de core/output: los tonos de una tarea son los mismos
+  tonos semánticos que ya usa cualquier comando, sin capa de traducción.
+*/
+
+import type { Line } from './output';
+
+/**
+ * Handle opaco de una línea ya escrita, para poder reescribirla. El motor no
+ * asume nada de su forma (hoy es el `HTMLDivElement` creado por `appendLine`).
+ */
+export type LineHandle = unknown;
+
+export interface TerminalSink {
+  /**
+   * Añade una línea al log y devuelve su handle. `announce` por defecto es
+   * `false`: la línea se marca `aria-hidden` para no leerla con lector de
+   * pantalla (las líneas de progreso no deben anunciar cada actualización).
+   */
+  write(line: Line, announce?: boolean): LineHandle;
+  /** Reemplaza el contenido de una línea ya escrita (spinner, barra, %). */
+  update(handle: LineHandle, line: Line): void;
+  /** Bloquea (`true`) o libera (`false`) el input mientras corre una tarea. */
+  busy(running: boolean): void;
+  /** `true` si el usuario pidió reducir movimiento (prefers-reduced-motion). */
+  reducedMotion(): boolean;
+}

--- a/src/modules/terminal/tasks/random.ts
+++ b/src/modules/terminal/tasks/random.ts
@@ -1,0 +1,39 @@
+/*
+  Bolsa barajada sin repetición inmediata. `createBag(items)` devuelve una
+  función que va entregando los items en orden aleatorio; al agotarse rebaraja,
+  GARANTIZANDO que el primero de la nueva tanda no repita el último de la
+  anterior. Con `Math.random()` puro sobre 5 elementos el mismo sale dos veces
+  seguidas más a menudo de lo que la gente intuye, y ahí se rompe la ilusión.
+*/
+
+/** Fisher–Yates sobre una copia; no muta el original. */
+function shuffled<T>(source: readonly T[]): T[] {
+  const arr = source.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function createBag<T>(items: readonly T[]): () => T {
+  if (items.length === 0) throw new Error('createBag: items vacío');
+  const source = items.slice();
+  let bag: T[] = [];
+  let last: T | undefined;
+
+  return () => {
+    if (bag.length === 0) {
+      bag = shuffled(source);
+      // Se entrega desde el final (pop O(1)). Si el próximo a salir repite el
+      // último de la tanda anterior, se intercambia con otra posición.
+      if (source.length > 1 && bag[bag.length - 1] === last) {
+        const j = Math.floor(Math.random() * (bag.length - 1));
+        [bag[bag.length - 1], bag[j]] = [bag[j], bag[bag.length - 1]];
+      }
+    }
+    const next = bag.pop() as T;
+    last = next;
+    return next;
+  };
+}

--- a/src/modules/terminal/tasks/runner.ts
+++ b/src/modules/terminal/tasks/runner.ts
@@ -1,0 +1,157 @@
+/*
+  Intérprete de un `TaskScript` contra un `TerminalSink`. Emite líneas DURANTE
+  la ejecución (no al final) y reescribe la misma línea para animar spinner y
+  barra — las dos capacidades que el contrato comando→renderer no tiene.
+
+  Reglas duras:
+  - `sink.busy(true)` al empezar y `busy(false)` en un `finally`, también si se
+    aborta o si lanza: si esa liberación se escapa, el input queda muerto.
+  - Toda espera y todo tick comprueban `signal.aborted` y salen limpios.
+  - Con `reducedMotion()`: sin esperas, imprimiendo solo el estado final de cada
+    paso. Sigue siendo legible y llega al mismo error.
+  - `fail` es la ÚNICA línea anunciada de toda la tarea, y la termina.
+
+  Glifos: VT323 (la fuente del log) NO cubre braille/bloques/box-drawing en su
+  propio archivo; esos solo salen por fallback del sistema, con métricas que no
+  encajan en una barra. Se usa ASCII, que la fuente SÍ trae, para que la barra
+  mantenga ancho constante sin depender del fallback.
+*/
+
+import type { Line, Tone } from '../core/output';
+import type { TerminalSink, LineHandle } from '../core/sink';
+import type { TaskScript, TaskStep } from './script';
+
+const SPINNER_FRAMES = ['|', '/', '-', '\\'] as const;
+const SPINNER_INTERVAL = 90; // ms por fotograma
+const PROGRESS_INTERVAL = 60; // ms por tick de barra
+const BAR_WIDTH = 14;
+
+/** Espera `ms`; resuelve de inmediato si el signal ya abortó o aborta antes. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(id);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Avance no lineal: rápido al principio, se atasca cerca del final. */
+function ease(t: number): number {
+  const clamped = t < 0 ? 0 : t > 1 ? 1 : t;
+  return Math.pow(clamped, 0.45);
+}
+
+function barText(pct: number): string {
+  const filled = Math.round((pct / 100) * BAR_WIDTH);
+  const clamped = Math.max(0, Math.min(BAR_WIDTH, filled));
+  return '[' + '#'.repeat(clamped) + '-'.repeat(BAR_WIDTH - clamped) + ']';
+}
+
+const spinnerLine = (label: Line, frame: string): Line => [
+  ...label,
+  { text: '  ' + frame, tone: 'accent' },
+];
+
+const spinnerDone = (label: Line): Line => [
+  ...label,
+  { text: '  ok', tone: 'ok' },
+];
+
+const progressLine = (label: Line, pct: number, tone: Tone): Line => [
+  ...label,
+  { text: '  ' + barText(pct) + ' ' + String(Math.round(pct)).padStart(3, ' ') + '%', tone },
+];
+
+async function runStep(
+  step: TaskStep,
+  sink: TerminalSink,
+  reduced: boolean,
+  signal?: AbortSignal,
+): Promise<void> {
+  switch (step.kind) {
+    case 'print': {
+      sink.write(step.line);
+      return;
+    }
+
+    case 'wait': {
+      if (reduced) return;
+      await sleep(step.ms, signal);
+      return;
+    }
+
+    case 'spinner': {
+      const handle: LineHandle = sink.write(spinnerLine(step.label, SPINNER_FRAMES[0]));
+      if (reduced) {
+        sink.update(handle, spinnerDone(step.label));
+        return;
+      }
+      const start = Date.now();
+      let frame = 0;
+      while (!signal?.aborted) {
+        const elapsed = Date.now() - start;
+        if (elapsed >= step.ms) break;
+        sink.update(handle, spinnerLine(step.label, SPINNER_FRAMES[frame % SPINNER_FRAMES.length]));
+        frame++;
+        await sleep(Math.min(SPINNER_INTERVAL, step.ms - elapsed), signal);
+      }
+      if (!signal?.aborted) sink.update(handle, spinnerDone(step.label));
+      return;
+    }
+
+    case 'progress': {
+      const tone: Tone = step.tone ?? 'data';
+      const handle: LineHandle = sink.write(progressLine(step.label, 0, tone));
+      if (reduced) {
+        sink.update(handle, progressLine(step.label, 100, tone));
+        return;
+      }
+      const start = Date.now();
+      while (!signal?.aborted) {
+        const elapsed = Date.now() - start;
+        if (elapsed >= step.ms) break;
+        const pct = ease(elapsed / step.ms) * 100;
+        sink.update(handle, progressLine(step.label, pct, tone));
+        await sleep(Math.min(PROGRESS_INTERVAL, step.ms - elapsed), signal);
+      }
+      if (!signal?.aborted) sink.update(handle, progressLine(step.label, 100, tone));
+      return;
+    }
+
+    case 'fail': {
+      // Única línea anunciada de toda la tarea.
+      sink.write(step.line, true);
+      return;
+    }
+  }
+}
+
+/**
+ * Ejecuta un script contra un sink. Resuelve cuando termina, se aborta o
+ * alcanza un paso `fail`. Nunca deja el input bloqueado: `busy(false)` va en
+ * `finally`.
+ */
+export async function runTask(
+  script: TaskScript,
+  sink: TerminalSink,
+  signal?: AbortSignal,
+): Promise<void> {
+  sink.busy(true);
+  const reduced = sink.reducedMotion();
+  try {
+    for (const step of script.steps) {
+      if (signal?.aborted) return;
+      await runStep(step, sink, reduced, signal);
+      if (step.kind === 'fail') return; // `fail` termina la tarea
+    }
+  } finally {
+    sink.busy(false);
+  }
+}

--- a/src/modules/terminal/tasks/script.ts
+++ b/src/modules/terminal/tasks/script.ts
@@ -1,0 +1,24 @@
+/*
+  Un script de tarea es una lista DECLARATIVA de pasos. No hace nada por sí
+  mismo: `runner.ts` lo interpreta contra un `TerminalSink`. Reutiliza `Line` y
+  `Tone` de core/output, así que un paso habla el mismo vocabulario de salida
+  que cualquier comando.
+*/
+
+import type { Line, Tone } from '../core/output';
+
+export type TaskStep =
+  /** Imprime una línea estática y sigue. */
+  | { kind: 'print'; line: Line }
+  /** Pausa `ms` sin escribir nada. */
+  | { kind: 'wait'; ms: number }
+  /** Línea con spinner giratorio durante `ms`; acaba en estado final sin spinner. */
+  | { kind: 'spinner'; label: Line; ms: number }
+  /** Línea con barra que llega al 100% en `ms`; avance no lineal. */
+  | { kind: 'progress'; label: Line; ms: number; tone?: Tone }
+  /** Línea de error anunciada; TERMINA la tarea. */
+  | { kind: 'fail'; line: Line };
+
+export interface TaskScript {
+  steps: TaskStep[];
+}


### PR DESCRIPTION
## Qué se construye

Un **motor de tareas asíncronas con salida progresiva** para la terminal FR-3D. El contrato actual —el comando devuelve todas sus líneas y el renderer las pinta después— no puede animar nada; faltaban dos capacidades:

1. **Emitir líneas durante la ejecución**, no al final.
2. **Reescribir una línea ya emitida** (una barra de progreso o un spinner son la misma línea mutando).

El comando `install` (oculto) es el primer consumidor, pero el motor amortiza más: secuencia de boot FR-3D, `git clone` simulado, latencia de FR-3D, etc.

## Arquitectura

El motor no toca el DOM: habla con un puerto (`TerminalSink`) que vive en `core/`, de modo que la dependencia va *tarea → terminal* y nunca al revés. Reutiliza `Line`/`Tone` de `core/output` — sin capa de traducción.

```
core/sink.ts        ← puerto (write/update/busy/reducedMotion)
core/registry.ts    ← ShellEffects gana `task`; ShellContext gana `packages`
tasks/script.ts     ← pasos declarativos (print/wait/spinner/progress/fail)
tasks/runner.ts     ← ejecuta un script contra un sink (abortable, reduced-motion)
tasks/random.ts     ← bolsa barajada sin repetición inmediata
commands/install.ts ← comando simulado
constants/INSTALL.ts← errores, paquetes y frases (bilingües)
components/Terminal.astro ← implementa el sink, busy y cancelación
```

## Cambios por fase (un commit por fase)

- **FASE 1 · Motor headless** — `TaskScript`/`runTask`/`createBag`. Emite líneas en vivo, reescribe spinner/barra, `busy(false)` en `finally`, abortable en cada paso y tick, salta al estado final con `prefers-reduced-motion`. Glifos **ASCII** porque VT323 (la fuente del log) no cubre bloques/braille en su propio archivo (verificado con fonttools); solo saldrían por fallback del sistema con métricas inconsistentes.
- **FASE 2 · Sink, busy y cancelación** — `Terminal.astro` implementa el sink reutilizando `appendLine` (ahora devuelve el `<div>` como handle) y `fillSegments` (el `update` nunca pierde el tono inline). Input `disabled` + `aria-busy` mientras corre una tarea (una a la vez; las teclas se descartan). Ctrl+C y Esc abortan (Esc a 3 niveles: tarea → pantalla completa → desenfoca).
- **FASE 3 · Comando `install`** — alias `bun`/`npm`/`pnpm`/`yarn` con su subcomando; subcomando no relacionado (`bun run`) → error normal sin animación; saneado de entrada (≤64 chars, sin control chars, máx 5 paquetes); paquetes reales de `package.json` extraídos en **build time** → "ya está instalado". Devuelve `ok()` sin líneas para no duplicar el render.
- **FASE 4 · Contenido** — 5 errores en 5 ejes distintos (`ENOTFOUND`, `EACCES`, `ENOSPC`, `EINTEGRITY`, `ETIMEDOUT`), realistas en la forma, cada uno con un guiño de FR-3D en personaje que aclara que es intencional sin explicar el chiste. Respuestas propias para `react`/`vue`/`svelte`/`next`/`tailwind` y un guiño único para `fr3d`/`hardcode-labs`.
- **FASE 5 · A11y y movimiento** — solo la línea de error (o de resultado) se anuncia, nunca las ~30 actualizaciones de la barra; `prefers-reduced-motion` salta al estado final; el foco se respeta en ambos sentidos; `pagehide` aborta la tarea en curso (sin temporizadores huérfanos).

## Decisiones abiertas del plan (aceptadas)

1. `install` **oculto** (el chiste es mejor encontrado que ofrecido).
2. `bun`/`npm`/`yarn` sin subcomando → muestran el uso, como el binario real.
3. Paquete con respuesta única: `install fr3d` / `install hardcode-labs`.

## Verificación (navegador real, Chromium)

- **Fuga de input:** abortar a media animación **5 veces seguidas** deja el input utilizable las 5; también por Esc y alternando pantalla completa a mitad.
- **Los 4 casos de `install`** en `/es/` y `/en/`; alias con subcomando; oculto en `help`; sin líneas duplicadas.
- **Rotación de errores:** 200 tandas × 15 tiradas → 0 repeticiones inmediatas y los 5 errores presentes en cada tanda.
- **A11y:** exactamente una línea anunciada por tarea (la de error/resultado); resto `aria-hidden`.
- **Reduced motion:** salta al estado final (~120 ms) llegando al mismo error.
- **Foco:** vuelve al input si el usuario seguía ahí; no se lo roba si se movió a otro elemento.
- **Scroll:** el log scrollea solo hasta el fondo, acoplado y en pantalla completa.
- `astro check`: sin errores nuevos en el módulo (los 2 errores restantes son preexistentes en `design-system.astro`).

## Fuera de alcance

Secuencia de boot FR-3D, otros comandos simulados (`git clone`, `curl`), instalaciones que "funcionen", persistencia entre sesiones. El motor los soporta; escribirlos es otro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011jxNscsrGVgN1DzCFnPRXE)_