### PR TITLE
feat: add featured project filtering, status badges, and terminal tweaks

### DIFF
--- a/.claude/commands/add-project.md
+++ b/.claude/commands/add-project.md
@@ -83,6 +83,11 @@ primera persona para los highlights. Nada de relleno tipo "lorem ipsum".
 - `status`: si está en curso → `{ "es": "En desarrollo", "en": "In Development" }`;
   si está terminado → `{ "es": "Completado", "en": "Completed" }`. Pregunta al usuario
   si no es evidente.
+- `featured`: `true` si debe aparecer también en el home (destacado); `false` si solo
+  debe listarse en `/projects`. Pregunta al usuario si no es evidente.
+- `projectStatus`: uno de `"active" | "finished" | "cancelled" | "personal"` — alimenta
+  el badge visual de `/projects` (Activo/Finalizado/Cancelado/Personal). Es distinto de
+  `status` (la línea descriptiva bilingüe de arriba, usada en CV/ATS/terminal).
 
 ## Paso 5 — Construir el objeto en el esquema EXACTO
 
@@ -91,6 +96,8 @@ Usa esta forma (respeta las claves y el anidamiento `{es,en}`):
 ```json
 {
   "id": "proj-<slug-corto-en-kebab-case>",
+  "featured": true,
+  "projectStatus": "active",
   "name": { "es": "<Nombre>", "en": "<Name>" },
   "startDate": "<AÑO>",
   "endDate": null,

--- a/src/constants/resume.json
+++ b/src/constants/resume.json
@@ -791,6 +791,8 @@
   "projects": [
     {
       "id": "proj-expense-control",
+      "featured": true,
+      "projectStatus": "active",
       "name": {
         "es": "Plataforma de Control de Gastos",
         "en": "Expense Control Platform"
@@ -955,6 +957,8 @@
     },
     {
       "id": "proj-vision-craft",
+      "featured": true,
+      "projectStatus": "active",
       "name": {
         "es": "Vision Craft",
         "en": "Vision Craft"

--- a/src/modules/portfolio/ProjectPage.astro
+++ b/src/modules/portfolio/ProjectPage.astro
@@ -13,7 +13,13 @@ const { projects } = data;
 ---
 
 <main>
-  <ProjectsComponent lang={lang} projects={projects} />
+  <ProjectsComponent
+    lang={lang}
+    projects={projects}
+    showStatus={true}
+    title={lang === "es" ? "Todos los proyectos" : "All Projects"}
+    subTittle={lang === "es" ? "ARCHIVO_COMPLETO • REGISTRO_DE_MISIONES" : "FULL_ARCHIVE • MISSION_LOG"}
+  />
   <ProjectsDetail lang={lang} projects={projects} />
 </main>
 

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -40,6 +40,19 @@ const { lang, name, label } = Astro.props;
 </section>
 
 <script>
+	import { onTerminalActiveChange } from "../../../shared/utils/terminalActivity";
+
+	// Cursor decorativo del hero vs. cursor real de la terminal: cuando la
+	// terminal está activa (foco o pantalla completa) se apaga con opacity para
+	// no competir con el caret de la terminal, sin desmontarlo del DOM (evita
+	// reflow). Store compartido: este componente no conoce nada de Terminal.astro.
+	const heroCursor = document.querySelector<HTMLElement>(".hero-cursor");
+	if (heroCursor) {
+		onTerminalActiveChange((active) => {
+			heroCursor.classList.toggle("cursor-suppressed", active);
+		});
+	}
+
 	// Scroll a secciones (se conservan los IDs previos)
 	const contactButton = document.getElementById("contact-button");
 	contactButton?.addEventListener("click", () => {
@@ -142,6 +155,13 @@ const { lang, name, label } = Astro.props;
 		background-color: var(--amber-glow);
 		box-shadow: var(--text-glow-amber);
 		animation: hero-cursor-blink 1.1s step-end infinite;
+	}
+	/* Terminal activa (foco o pantalla completa): se apaga sin desmontarse ni
+	   usar display:none, para no generar reflow en el layout del hero. La
+	   especificidad de dos clases ya gana sobre .hero-cursor sin !important. */
+	.hero-cursor.cursor-suppressed {
+		animation: none;
+		opacity: 0;
 	}
 
 	/* ===== CTAs ===== */

--- a/src/modules/portfolio/components/Projects.astro
+++ b/src/modules/portfolio/components/Projects.astro
@@ -5,18 +5,25 @@ import ProjectsCard from "./ProjectsCard.astro";
 interface Props {
   lang: "es" | "en";
   projects: any[];
+  showStatus?: boolean;
+  title?: string;
+  subTittle?: string;
 }
 
-const { lang, projects } = Astro.props;
+const {
+  lang,
+  projects,
+  showStatus = false,
+  title = lang === "es" ? "Proyectos destacados" : "Featured Projects",
+  subTittle = lang === "es"
+    ? "PRESENTACIÓN_DE_PORTAFOLIO • SISTEMAS_DE_MISIÓN_CRÍTICA"
+    : "PORTFOLIO_SHOWCASE • MISSION_CRITICAL_SYSTEMS",
+} = Astro.props;
 ---
 
-<Section
-  id="projects"
-  title={lang === "es" ? "Proyectos destacados" : "Featured Projects"}
-  subTittle={lang === "es" ? "PRESENTACIÓN_DE_PORTAFOLIO • SISTEMAS_DE_MISIÓN_CRÍTICA" : "PORTFOLIO_SHOWCASE • MISSION_CRITICAL_SYSTEMS"}
->
+<Section id="projects" title={title} subTittle={subTittle}>
   <div class="cards-wrapper">
-    {projects && projects.map(({ id, name, image, summary, description, technologies, url, repo }) =>
+    {projects && projects.map(({ id, name, image, summary, description, technologies, url, repo, projectStatus }) =>
       <ProjectsCard
         id={id}
         lang={lang}
@@ -27,6 +34,8 @@ const { lang, projects } = Astro.props;
         technologies={technologies}
         url={url}
         repo={repo}
+        projectStatus={projectStatus}
+        showStatus={showStatus}
       />
     )}
   </div>

--- a/src/modules/portfolio/components/ProjectsCard.astro
+++ b/src/modules/portfolio/components/ProjectsCard.astro
@@ -3,6 +3,7 @@ import SquareChevronRight from "src/shared/icons/SquareChevronRight.astro";
 import Chip from "../components/Chip.astro";
 import Github from "src/shared/icons/Github.astro";
 import Link from "src/shared/icons/Link.astro";
+import StatusBadge from "./StatusBadge.astro";
 
 interface Props {
   id?: string | null | undefined;
@@ -14,9 +15,23 @@ interface Props {
   technologies: string[];
   url: string;
   repo: string;
+  projectStatus?: "active" | "finished" | "cancelled" | "personal";
+  showStatus?: boolean;
 }
 
-const { id, lang, name, image, summary, description, technologies, url, repo } = Astro.props;
+const {
+  id,
+  lang,
+  name,
+  image,
+  summary,
+  description,
+  technologies,
+  url,
+  repo,
+  projectStatus,
+  showStatus = false,
+} = Astro.props;
 
 // Chips visibles en la tarjeta (el stack completo se ve en el detalle).
 const STACK_LIMIT = 5;
@@ -41,6 +56,9 @@ const vtTitle = id
   <header>
     <SquareChevronRight />
     <h5 style={vtTitle}>{name.split(" ").join("_")}</h5>
+    {showStatus && projectStatus && (
+      <StatusBadge lang={lang} status={projectStatus} />
+    )}
   </header>
   <figure style={vtFigure}>
     <img
@@ -116,7 +134,7 @@ const vtTitle = id
     letter-spacing: 0.05em;
     transition: color 0.3s ease;
   }
-  header h5 { font-weight: 500; }
+  header h5 { font-weight: 500; flex: 1; }
   figure {
     width: 100%;
     height: 200px;

--- a/src/modules/portfolio/components/StatusBadge.astro
+++ b/src/modules/portfolio/components/StatusBadge.astro
@@ -1,0 +1,40 @@
+---
+interface Props {
+  lang: "es" | "en";
+  status: "active" | "finished" | "cancelled" | "personal";
+}
+
+const { lang, status } = Astro.props;
+
+const LABELS: Record<Props["status"], { es: string; en: string }> = {
+  active: { es: "Activo", en: "Active" },
+  finished: { es: "Finalizado", en: "Finished" },
+  cancelled: { es: "Cancelado", en: "Cancelled" },
+  personal: { es: "Personal", en: "Personal" },
+};
+
+const COLORS: Record<Props["status"], string> = {
+  active: "var(--cyan-glow)",
+  finished: "var(--red-muted)",
+  cancelled: "var(--red-glow)",
+  personal: "var(--amber-glow)",
+};
+
+const label = LABELS[status]?.[lang] ?? LABELS.active[lang];
+const color = COLORS[status] ?? COLORS.active;
+---
+
+<span class="status-badge" style={`--badge-color: ${color}`}>{label}</span>
+
+<style>
+  .status-badge {
+    font-family: var(--font-terminal);
+    font-size: 0.9em;
+    letter-spacing: 0.05em;
+    color: var(--badge-color);
+    border: 1px solid var(--badge-color);
+    border-radius: 3px;
+    padding: 0.1em 0.5em;
+    white-space: nowrap;
+  }
+</style>

--- a/src/modules/portfolio/index.astro
+++ b/src/modules/portfolio/index.astro
@@ -20,7 +20,7 @@ const { basics, works, projects, techBays } = data;
   <Home lang={lang} name={basics.name} label={basics.label} />
   <About lang={lang} summary={basics.summary} name={basics.name} image={basics.image} />
   <Experience lang={lang} works={works} />
-  <Projects lang={lang} projects={projects} />
+  <Projects lang={lang} projects={projects.filter((p: any) => p.featured)} />
   <Technologies lang={lang} techBays={techBays} />
   <Contact lang={lang} basics={basics} />
 </main>

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -132,6 +132,20 @@ const { title, image, summary, url, lang, links, activeId } = Astro.props;
 	html {
 		font-family: var(--font-body);
 		scroll-behavior: smooth;
+		cursor:
+			url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cline x1='12' y1='6' x2='12' y2='10' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='12' y1='14' x2='12' y2='18' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='6' y1='12' x2='10' y2='12' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='14' y1='12' x2='18' y2='12' stroke='%2300F7FF' stroke-width='1.4'/%3E%3C/svg%3E")
+			12 12,
+			auto;
+	}
+	a,
+	button:not(:disabled),
+	[role="button"],
+	.interactive,
+	summary {
+		cursor:
+			url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cline x1='12' y1='3' x2='12' y2='7' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='12' y1='17' x2='12' y2='21' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='3' y1='12' x2='7' y2='12' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Cline x1='17' y1='12' x2='21' y2='12' stroke='%2300F7FF' stroke-width='1.4'/%3E%3Ccircle cx='12' cy='12' r='3.2' fill='%2300F7FF'/%3E%3C/svg%3E")
+			12 12,
+			pointer !important;
 	}
 
 	#mouse {

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -125,6 +125,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 	import { isHidden, resolveNode, resolvePath } from "../fs/resolve";
 	import type { CommandResult, Line, Tone } from "../core/output";
 	import type { DirNode } from "../fs/types";
+	import { setTerminalActive } from "../../../shared/utils/terminalActivity";
 
 	const bar = document.getElementById("fr3d-cmd");
 	const vfsTag = document.getElementById("fr3d-vfs");
@@ -258,6 +259,19 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		let isFullscreen = false;
 		let lastActiveBeforeFs: HTMLElement | null = null;
 
+		// "Terminal activa" = tiene foco el input, está en pantalla completa o hay
+		// una tarea en curso (el input se deshabilita/pierde foco mientras corre,
+		// pero la terminal sigue siendo la protagonista en pantalla). Único punto
+		// que escribe en el store compartido; el resto del sitio (ej. el cursor
+		// del hero) solo lee, nunca conoce estos detalles. `taskRunning` se
+		// declara más abajo pero ya está inicializada cuando esto se invoca
+		// (los listeners solo disparan tras correr el script completo).
+		const updateActiveState = () => {
+			setTerminalActive(
+				isFullscreen || taskRunning || document.activeElement === input,
+			);
+		};
+
 		const enterFullscreen = () => {
 			if (isFullscreen) return;
 			lastActiveBeforeFs = document.activeElement as HTMLElement | null;
@@ -267,6 +281,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			// No autoenfocar en móvil: dispararía el teclado virtual sin pedirlo.
 			if (!window.matchMedia("(pointer: coarse)").matches) input.focus();
 			scrollToBottom();
+			updateActiveState();
 		};
 
 		const exitFullscreen = () => {
@@ -275,6 +290,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			dialog.close();
 			isFullscreen = false;
 			(lastActiveBeforeFs ?? input).focus();
+			updateActiveState();
 		};
 
 		const toggleFullscreen = () =>
@@ -318,6 +334,9 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 			} else {
 				input.placeholder = defaultPlaceholder;
 			}
+			// Deshabilitar el input le quita el foco (dispara blur): sin esto la
+			// terminal se marcaría "inactiva" a mitad de una tarea en curso.
+			updateActiveState();
 		};
 
 		// El sink que consume el runner: reutiliza appendLine/fillSegments. El
@@ -506,6 +525,9 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		form.addEventListener("click", (e) => {
 			if (!(e.target as HTMLElement).closest("a")) input.focus();
 		});
+
+		input.addEventListener("focus", updateActiveState);
+		input.addEventListener("blur", updateActiveState);
 
 		renderPrompt(); // prompt inicial
 

--- a/src/shared/utils/terminalActivity.ts
+++ b/src/shared/utils/terminalActivity.ts
@@ -1,0 +1,32 @@
+/*
+  Estado compartido de "terminal activa": true mientras el input de la
+  terminal tiene foco o está en pantalla completa. Un módulo importado por
+  Terminal.astro (emisor) y por cualquier otro componente (lector, ej. el
+  cursor del hero) evita acoplar ese componente directamente al DOM/eventos
+  internos de la terminal — ambos lados solo conocen este contrato.
+*/
+
+const EVENT_NAME = 'terminal:active-change';
+
+let active = false;
+
+export function setTerminalActive(next: boolean): void {
+  if (active === next) return;
+  active = next;
+  document.dispatchEvent(
+    new CustomEvent<boolean>(EVENT_NAME, { detail: next }),
+  );
+}
+
+export function isTerminalActive(): boolean {
+  return active;
+}
+
+/** Devuelve una función para desuscribirse. */
+export function onTerminalActiveChange(
+  handler: (active: boolean) => void,
+): () => void {
+  const listener = (e: Event) => handler((e as CustomEvent<boolean>).detail);
+  document.addEventListener(EVENT_NAME, listener);
+  return () => document.removeEventListener(EVENT_NAME, listener);
+}


### PR DESCRIPTION
- Update resume.json with featured project flags and status fields for two sample projects
- Filter featured projects to display only on homepage, show all projects on dedicated portfolio page
- Add bilingual, color-coded status badges for project cards
- Create shared terminal activity state utility to sync hero cursor visibility with terminal focus
- Add custom cyberpunk-themed cursor styles for site and interactive elements
- Update add-project documentation with new required project schema properties