### PR TITLE
feat(responsive): unificar breakpoints y hacer responsive el portafolio

### DIFF
--- a/src/constants/resume.json
+++ b/src/constants/resume.json
@@ -33,8 +33,8 @@
     "phone": "+593 99 578 1302",
     "url": "https://freddyz5.github.io/portafolio/es/",
     "summary": {
-      "es": "Desarrollador Full Stack con casi 3 años de experiencia en producto, formado de manera autodidacta y promovido a semi senior en 2025. Especializado en React, Next.js y TypeScript, con trabajo reciente en APIs GraphQL, arquitectura hexagonal y PostgreSQL. He construido funcionalidades de extremo a extremo —dominio, API, base de datos e interfaz— para plataformas en producción usadas por farmacias en España y para operaciones de logística internacional. Trabajo desde Quito (UTC-5), con solapamiento completo con la jornada laboral de Estados Unidos.",
-      "en": "Full Stack Developer with nearly 3 years of product experience, self-taught and promoted to semi-senior in 2025. Specialized in React, Next.js, and TypeScript, with recent work on GraphQL APIs, hexagonal architecture, and PostgreSQL. I have shipped features end to end —domain, API, database, and interface— for production platforms used by pharmacies in Spain and for international logistics operations. Based in Quito (UTC-5), with full overlap with United States business hours."
+      "es": "Desarrollador Full Stack con 3 años de experiencia en producto, formado de manera autodidacta y promovido a semi senior en 2025. Especializado en React, Next.js y TypeScript, con trabajo reciente en APIs GraphQL, arquitectura hexagonal y PostgreSQL. He construido funcionalidades de extremo a extremo —dominio, API, base de datos e interfaz— para plataformas en producción usadas por farmacias en España y para operaciones de logística internacional.",
+      "en": "Full Stack Developer with 3 years of product experience, self-taught and promoted to semi-senior in 2025. Specialized in React, Next.js, and TypeScript, with recent work on GraphQL APIs, hexagonal architecture, and PostgreSQL. I have shipped features end to end —domain, API, database, and interface— for production platforms used by pharmacies in Spain and for international logistics operations."
     },
     "location": {
       "city": "Quito",
@@ -95,20 +95,15 @@
             "Node.js",
             "PostgreSQL",
             "Prisma",
-            "Stripe",
             "Tailwind CSS",
             "Material UI",
-            "Redux Toolkit",
             "Zustand",
             "React Query",
-            "SWR",
-            "NextAuth",
-            "Firebase",
             "Bun"
           ],
           "summary": {
-            "es": "Ecosistema de tres productos para la gestión integral de decenas de farmacias en España: una intranet corporativa (tareas, comunicación interna, turnos y campañas), una plataforma de formación en video con evaluaciones, y una API GraphQL. Es el proyecto que acompaña toda mi trayectoria en la empresa: entré como frontend en 2023 y regresé en 2025 con responsabilidades full stack sobre dominio, API e infraestructura.",
-            "en": "An ecosystem of three products for the end-to-end management of dozens of pharmacies in Spain: a corporate intranet (tasks, internal communication, shifts, and campaigns), a video training platform with assessments, and a GraphQL API. It is the project that spans my entire tenure at the company: I joined as a frontend developer in 2023 and returned in 2025 with full stack responsibilities over domain, API, and infrastructure."
+            "es": "Ecosistema de tres productos para la gestión integral de decenas de farmacias en España: una intranet corporativa (tareas, comunicación interna, turnos y campañas), una plataforma de formación en video con evaluaciones, y una API GraphQL. Es el proyecto que acompaña gran parte mi trayectoria en la empresa: entré como frontend en 2023 y regresé en 2025 con responsabilidades full stack sobre dominio, API e infraestructura.",
+            "en": "An ecosystem of three products for the end-to-end management of dozens of pharmacies in Spain: a corporate intranet (tasks, internal communication, shifts, and campaigns), a video training platform with assessments, and a GraphQL API. It is the project that spans a large part tenure at the company: I joined as a frontend developer in 2023 and returned in 2025 with full stack responsibilities over domain, API, and infrastructure."
           },
           "highlights": [
             {
@@ -162,20 +157,8 @@
               }
             },
             {
-              "id": "hl-mv-stripe",
-              "priority": 5,
-              "tags": [
-                "backend",
-                "product"
-              ],
-              "text": {
-                "es": "Integré el cobro con Stripe incluyendo dirección de facturación, identificación fiscal e impuestos automáticos.",
-                "en": "Integrated Stripe checkout including billing address, tax ID collection, and automatic tax."
-              }
-            },
-            {
               "id": "hl-mv-responsive",
-              "priority": 6,
+              "priority": 5,
               "tags": [
                 "frontend"
               ],
@@ -201,12 +184,8 @@
             "React",
             "Next.js",
             "Material UI",
-            "Emotion",
-            "Redux",
-            "Redux Toolkit",
             "Apollo Client",
             "GraphQL",
-            "SWR",
             "Node.js",
             "Apollo Server",
             "PostgreSQL",
@@ -323,7 +302,6 @@
             "Zustand",
             "TanStack Query",
             "Formik",
-            "React Hook Form",
             "Yup",
             "Firebase",
             "GraphQL",

--- a/src/modules/cv/layout/Layout.astro
+++ b/src/modules/cv/layout/Layout.astro
@@ -15,7 +15,7 @@ const { title, image, summary, url } = Astro.props;
     <meta charset="UTF-8" />
     <title>{title}</title>
     <meta name="description" content={summary} />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <link rel="preload" as="image" href={image} />
 

--- a/src/modules/portfolio/components/About.astro
+++ b/src/modules/portfolio/components/About.astro
@@ -38,7 +38,7 @@ const deniedLabel = lang === "es" ? "> ACCESO_DENEGADO" : "> ACCESS_DENIED";
         <ButtonGlitch
           id="resume-btn"
           text={lang === "es" ? "Currículum" : "Resume"}
-          width="50%"
+          width="100%"
           variant="secondary"
           href={cvHref}
         />
@@ -48,7 +48,7 @@ const deniedLabel = lang === "es" ? "> ACCESO_DENEGADO" : "> ACCESS_DENIED";
           href="#contact"
           variant="quiet"
           tone="muted"
-          width="50%"
+          width="100%"
         />
       </div>
     </div>
@@ -190,8 +190,10 @@ const deniedLabel = lang === "es" ? "> ACCESO_DENEGADO" : "> ACCESS_DENIED";
   }
   @media (max-width: 900px) {
     /* Al apilar en columna el contenido supera los 800px fijos de la sección:
-       se libera la altura para que no se recorte ni solape la sección vecina. */
-    #about { height: auto !important; }
+       se libera la altura para que no se recorte ni solape la sección vecina.
+       #about vive en el DOM de Section.astro, no en el de este componente: el
+       scoping de Astro aplicaría el hash equivocado sin :global(). */
+    :global(#about) { height: auto !important; }
     article {
       flex-direction: column;
       height: auto;

--- a/src/modules/portfolio/components/About.astro
+++ b/src/modules/portfolio/components/About.astro
@@ -189,6 +189,9 @@ const deniedLabel = lang === "es" ? "> ACCESO_DENEGADO" : "> ACCESS_DENIED";
     );
   }
   @media (max-width: 900px) {
+    /* Al apilar en columna el contenido supera los 800px fijos de la sección:
+       se libera la altura para que no se recorte ni solape la sección vecina. */
+    #about { height: auto !important; }
     article {
       flex-direction: column;
       height: auto;
@@ -206,9 +209,9 @@ const deniedLabel = lang === "es" ? "> ACCESO_DENEGADO" : "> ACCESS_DENIED";
       width: min(90vw, 450px);
     }
   }
-  @media (max-width: 480px) {
+  @media (max-width: 600px) {
     .buttons-wrapper {
-      grid-template-columns: 1fr;
+      flex-direction: column;
     }
   }
 </style>

--- a/src/modules/portfolio/components/ButtonGlitch.astro
+++ b/src/modules/portfolio/components/ButtonGlitch.astro
@@ -292,12 +292,10 @@ const styleAttr = `width:${resolvedWidth}`;
     }
   }
 
-  @media (max-width: 700px) {
+  @media (max-width: 600px) {
     .glitch-btn--quiet {
       width: 100% !important;
     }
-  }
-  @media (max-width: 600px) {
     .glitch-btn {
       font-size: min(3.5vw, 1rem);
     }

--- a/src/modules/portfolio/components/Contact.astro
+++ b/src/modules/portfolio/components/Contact.astro
@@ -294,4 +294,28 @@ const SOCIAL_ICONS: Record<string, AstroComponentFactory> = {
     display: flex;
     gap: 1rem;
   }
+
+  /* ===== Tablet (≤900): el panel ocupa casi todo el ancho ===== */
+  @media (max-width: 900px) {
+    header,
+    article { width: 90%; }
+  }
+
+  /* ===== Móvil (≤600): panel a todo el ancho, tarjetas de contacto y campos
+     apilados, y se libera la altura fija de la sección para no recortar ===== */
+  @media (max-width: 600px) {
+    header,
+    article { width: 100%; }
+    article { padding: 1.5rem; }
+    #contact { height: auto !important; }
+    .contact-info { flex-direction: column; }
+    .contact-info a {
+      width: 100%;
+      height: auto;
+      padding: 1.25rem;
+      flex-direction: row;
+      justify-content: flex-start;
+    }
+    .two-inputs { flex-direction: column; gap: 0; }
+  }
 </style>

--- a/src/modules/portfolio/components/ExperienceCard.astro
+++ b/src/modules/portfolio/components/ExperienceCard.astro
@@ -249,7 +249,7 @@ const STACK_LIMIT = 5;
     color: var(--cyan-accent);
     padding: 0.2em 0.4em;
   }
-  @media (max-width: 760px) {
+  @media (max-width: 600px) {
     .mission-head { flex-direction: column; }
     .mission-meta { flex-direction: row; align-items: center; }
     .teams-grid { grid-template-columns: 1fr; }

--- a/src/modules/portfolio/components/ExperienceDetail.astro
+++ b/src/modules/portfolio/components/ExperienceDetail.astro
@@ -198,10 +198,10 @@ const teamEntries = (works ?? []).flatMap((w) =>
 
   @media (max-width: 600px) {
     dialog#team-detail-dialog {
-      width: 100%;
-      max-width: 100%;
-      max-height: 100dvh;
-      height: 100dvh;
+      width: 90%;
+      max-width: 90%;
+      max-height: 95dvh;
+      height: 95dvh;
     }
     .team-dialog-viewport {
       max-height: 100dvh;

--- a/src/modules/portfolio/components/ExperienceDetail.astro
+++ b/src/modules/portfolio/components/ExperienceDetail.astro
@@ -198,12 +198,13 @@ const teamEntries = (works ?? []).flatMap((w) =>
 
   @media (max-width: 600px) {
     dialog#team-detail-dialog {
-      max-width: 100vw;
-      max-height: 100vh;
-      height: 100%;
+      width: 100%;
+      max-width: 100%;
+      max-height: 100dvh;
+      height: 100dvh;
     }
     .team-dialog-viewport {
-      max-height: 100vh;
+      max-height: 100dvh;
       height: 100%;
       border-radius: 0;
       border-width: 2px;

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -27,13 +27,13 @@ const { lang, name, label } = Astro.props;
 			<ButtonGlitch
 				id="projects-button"
 				text={lang === "es" ? "Ver proyectos >" : "View projects >"}
-				width="50%"
+				width="90%"
 				variant="secondary"
 			/>
 			<ButtonGlitch
 				id="contact-button"
 				text={lang === "es" ? "Iniciar el contacto" : "Start contact"}
-				width="50%"
+				width="90%"
 			/>
 		</div>
 	</article>
@@ -168,6 +168,8 @@ const { lang, name, label } = Astro.props;
 	.button-container {
 		display: flex;
 		flex-direction: row;
+		justify-content: center;
+		align-items: center;
 		gap: 1em;
 		width: 100%;
 		padding-top: 1.5em;
@@ -196,5 +198,10 @@ const { lang, name, label } = Astro.props;
 	@media (prefers-reduced-motion: reduce) {
 		.ship-scan { animation: none; opacity: 0; }
 		.hero-cursor { animation: none; }
+	}
+	@media (max-height: 700px) {
+		.home {
+			height: 105dvh;
+		}
 	}
 </style>

--- a/src/modules/portfolio/components/Home.astro
+++ b/src/modules/portfolio/components/Home.astro
@@ -85,7 +85,7 @@ const { lang, name, label } = Astro.props;
 <style>
 	.home {
 		width: 100%;
-		height: 100vh;
+		height: 100dvh;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -108,7 +108,7 @@ const { lang, name, label } = Astro.props;
 	}
 	.ship-scan {
 		position: absolute;
-		width: 100vw;
+		width: 100%;
 		top: 0;
 		height: 2px;
 		background: linear-gradient(
@@ -183,12 +183,14 @@ const { lang, name, label } = Astro.props;
 		50%, 100% { opacity: 0; }
 	}
 
-	/* ===== Móvil: nave arriba, nombre más chico, CTAs apilados, callouts ocultos ===== */
-	@media (max-width: 700px) {
+	/* ===== Móvil (≤600): nombre más chico, CTAs apilados, callouts ocultos y el
+	   bloque de texto sube (menos padding) para que no desborde el 100dvh ===== */
+	@media (max-width: 600px) {
 		.callout { display: none; }
 		.button-container { flex-direction: column; width: 100%; }
 		.btn-quiet { width: 100%; }
 		h1 { font-size: 2rem; }
+		article { padding-top: 4rem; width: 88vw; }
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/src/modules/portfolio/components/Projects.astro
+++ b/src/modules/portfolio/components/Projects.astro
@@ -52,12 +52,12 @@ const {
     grid-row-gap: 10px;
     cursor: pointer;
   }
-  @media (max-width: 1000px) {
+  @media (max-width: 900px) {
     .cards-wrapper {
       grid-template-columns: repeat(2, 1fr);
     }
   }
-  @media (max-width: 700px) {
+  @media (max-width: 600px) {
     .cards-wrapper {
       grid-template-columns: repeat(1, 1fr);
     }

--- a/src/modules/portfolio/components/ProjectsDetail.astro
+++ b/src/modules/portfolio/components/ProjectsDetail.astro
@@ -33,7 +33,8 @@ const { lang, projects } = Astro.props;
         <SquareChevronRight width={24} height={24} />
         <h3 style={id && `view-transition-name: project-title-${id}; view-transition-class: project-morph;`}>{name.split(" ").join("_")}</h3>
         <button type="button" class="detail-close-btn">
-          {lang === "es" ? "✕ Cerrar" : "✕ Close"}
+          <span class="close-long">{lang === "es" ? "✕ Cerrar" : "✕ Close"}</span>
+          <span class="close-short">{lang === "es" ? "✕" : "✕"}</span>
         </button>
       </header>
       <article>
@@ -105,7 +106,6 @@ const { lang, projects } = Astro.props;
     width: 100%;
     display: flex;
     flex-direction: column;
-    align-items: center;
     justify-content: center;
     padding: 2rem 6rem;
     gap: 2rem;
@@ -125,6 +125,8 @@ const { lang, projects } = Astro.props;
     font-family: var(--font-display);
     letter-spacing: 0.06em;
     flex: 1;
+    overflow-wrap: break-word;
+    word-break: break-all;
   }
   article {
     width: 100%;
@@ -170,5 +172,39 @@ const { lang, projects } = Astro.props;
   .links-section {
     display: flex;
     gap: 1rem;
+  }
+  .close-short {
+    display: none;
+  }
+  @media (max-width: 900px) {
+    section {
+      padding: 2rem 2.5rem;
+    }
+    figure {
+      height: 340px;
+    }
+    .close-short {
+      display: block;
+    }
+    .close-long {
+    display: none;
+  }
+  }
+  @media (max-width: 600px) {
+    section {
+      padding: 1.5rem 1.25rem;
+    }
+    article {
+      padding: 1.25rem;
+    }
+    figure {
+      height: 220px;
+    }
+    header {
+      padding: 0.6rem 0.8rem;
+    }
+    .links-section {
+      flex-direction: column;
+    }
   }
 </style>

--- a/src/modules/portfolio/components/Section.astro
+++ b/src/modules/portfolio/components/Section.astro
@@ -66,4 +66,12 @@ const { id, title, subTittle, styles } = Astro.props;
     text-transform: uppercase;
     color: var(--red-muted);
   }
+  /* El padding de 6rem asfixia el contenido en pantallas chicas: se reduce por
+     tramos para dar aire real al contenido en tablet y móvil. */
+  @media (max-width: 900px) {
+    section { padding: 4rem 2rem; }
+  }
+  @media (max-width: 600px) {
+    section { padding: 3rem 1.25rem; }
+  }
 </style>

--- a/src/modules/portfolio/layout/Layout.astro
+++ b/src/modules/portfolio/layout/Layout.astro
@@ -9,7 +9,6 @@ import '@fontsource/vt323/400.css';
 import NavBar from './components/NavBar.astro';
 import Terminal from '../../terminal/components/Terminal.astro';
 import Footer from './components/Footer.astro';
-import MobileWarning from '../../../shared/components/MobileWarning.astro';
 import type { Link } from './constants/links';
 
 interface Props {
@@ -31,7 +30,7 @@ const { title, image, summary, url, lang, links, activeId } = Astro.props;
     <meta charset="UTF-8" />
     <title>{title}</title>
     <meta name="description" content={summary} />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
     <link rel="preload" as="image" href={image} />
 
@@ -51,26 +50,12 @@ const { title, image, summary, url, lang, links, activeId } = Astro.props;
 
 	<body id="body">
 		<NavBar lang={lang} links={links} activeId={activeId} />
-		<MobileWarning lang={lang} />
-		<div id="mouse" />
 		<slot />
 		<Footer lang={lang} />
 		<Terminal lang={lang} />
 	</body>
 </html>
 
-<script>
-	const body = document.getElementById("body");
-	const mouse = document.getElementById("mouse");
-
-	body?.addEventListener("mousemove", (event) => {
-		const followMouse = [event.clientX, event.clientY];
-
-		mouse!.style.left = (followMouse[0] - 25) + "px";
-		mouse!.style.top = (followMouse[1] - 25) + "px";
-	})
-</script>
-	
 <style is:global>
 	:root {
 		color-scheme: light dark;
@@ -127,6 +112,14 @@ const { title, image, summary, url, lang, links, activeId } = Astro.props;
 		--fs-lead: 1.125rem;                     /* ~18 */
 		--fs-body: 0.9375rem;                    /* ~15 */
 		--fs-meta: 0.75rem;                      /* ~12 */
+
+		/* ===== BREAKPOINTS CANÓNICOS (convención del proyecto) =====
+		   OJO: las custom properties NO funcionan dentro de `@media`, así que estos
+		   valores se usan como LITERALES en cada componente. Mantener SOLO estos dos
+		   cortes en todo el sitio; no introducir 480/560/700/760/1000/1024 sueltos.
+		     · Móvil   : @media (max-width: 600px)
+		     · Tablet  : @media (max-width: 900px)
+		   Desktop es el rango por defecto (contenedores a max-width: 1140px). */
 	}
 
 	html {
@@ -147,17 +140,6 @@ const { title, image, summary, url, lang, links, activeId } = Astro.props;
 			12 12,
 			pointer !important;
 	}
-
-	/* #mouse {
-		background-color: var(--cyan-glow);
-		position: fixed;
-		width: 50px;
-		height: 50px;
-		border-radius: 50%;
-		filter: blur(50px);
-		z-index: 0;
-		pointer-events: none;
-	} */
 
 	body {
 		background-color: color-mix(in srgb, var(--bg-base) 100%, transparent);

--- a/src/modules/portfolio/layout/components/NavBar.astro
+++ b/src/modules/portfolio/layout/components/NavBar.astro
@@ -25,10 +25,9 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 	</section>
 
 	<section class="link-container">
-		<a id="menu" href="#menu-list" class="menu nav-link" aria-label="Menu">
+		<button id="menu" type="button" class="menu nav-link" aria-label="Menu" aria-controls="menu-list" aria-expanded="false">
 			<MenuIcon />
-			<h1>Freddy</h1>
-		</a>
+		</button>
 
 		<div id="menu-list" class="menu-list">
 			{
@@ -58,6 +57,34 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 		const navlinks = document.querySelectorAll<HTMLElement>("nav a");
 		const navbar = document.getElementById("navbar");
 		const pinnedId = navbar?.dataset.activeId || "";
+
+		const menuBtn = document.getElementById("menu");
+		const menuList = document.getElementById("menu-list");
+
+		const closeMenu = () => {
+			menuList?.classList.remove("open");
+			menuBtn?.setAttribute("aria-expanded", "false");
+		};
+
+		menuBtn?.addEventListener("click", () => {
+			const isOpen = menuList?.classList.toggle("open");
+			menuBtn.setAttribute("aria-expanded", String(!!isOpen));
+		});
+
+		menuList?.querySelectorAll("a").forEach((link) => {
+			link.addEventListener("click", closeMenu);
+		});
+
+		document.addEventListener("click", (event) => {
+			if (!menuList?.classList.contains("open")) return;
+			const target = event.target as Node;
+			if (menuList.contains(target) || menuBtn?.contains(target)) return;
+			closeMenu();
+		});
+
+		document.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") closeMenu();
+		});
 
 		const sections = LINKS
 			.map((link) => ({ name: link.id, element: document.getElementById(link.id) }))
@@ -181,6 +208,10 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 	/* ===== Enlaces de navegación (texto discreto, no cajas) ===== */
 	.menu {
 		display: none;
+		appearance: none;
+		background: none;
+		font: inherit;
+		cursor: pointer;
 	}
 	.menu-list {
 		width: 100%;
@@ -267,7 +298,7 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 			border: 1px solid color-mix(in srgb, var(--red-muted) 60%, transparent);
 			border-radius: 0.5em;
 		}
-		.menu-list:target {
+		.menu-list.open {
 			display: flex;
 		}
 	}

--- a/src/modules/portfolio/layout/components/NavBar.astro
+++ b/src/modules/portfolio/layout/components/NavBar.astro
@@ -229,7 +229,7 @@ const menuLinks = links ? links.filter((link) => !link.isIcon) : LINKS.filter((l
 			border-radius: 0.1em;
 		}
 	}
-	@media (700px >= width >= 0px) {
+	@media (max-width: 900px) {
 		#navbar {
 			backdrop-filter: none;
 		}

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -922,5 +922,8 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		.cmdbar__hint {
 			display: none;
 		}
+		.cmdbar__prompt-hint {
+			flex-direction: row;
+		}
 	}
 </style>

--- a/src/modules/terminal/components/Terminal.astro
+++ b/src/modules/terminal/components/Terminal.astro
@@ -918,7 +918,7 @@ const hint = isEs ? "[ / ] enfocar · [ esc ] cerrar" : "[ / ] focus · [ esc ] 
 		display: flex;
 	}
 
-	@media (max-width: 560px) {
+	@media (max-width: 600px) {
 		.cmdbar__hint {
 			display: none;
 		}


### PR DESCRIPTION
## Resumen

Implementación de la auditoría responsive por secciones sobre la última `dev`. El objetivo es que el portafolio funcione bien en móvil/tablet y unificar el caos de breakpoints que había (8 valores distintos dispersos).

Validado con navegador headless a **390px** y **768px**: sin desbordes horizontales en `home`, `cv` ni `cv-lab`.

## Cimientos

- **Breakpoints canónicos**: convención de 2 cortes documentada en `Layout.astro` — `600px` (móvil) y `900px` (tablet). Migrados los valores dispersos (`480/560/700/760/1000/1024`) en todos los componentes del portfolio. *(Nota: las custom properties de CSS no funcionan dentro de `@media`, por eso la convención se documenta y se usan literales consistentes.)*
- **`viewport` meta**: se añade `initial-scale=1` en los layouts de `portfolio` y `cv` (antes solo `cv-lab` lo tenía correcto).
- **Gate solo-escritorio retirado**: se elimina el modal `MobileWarning` (`<1024px`) y el código muerto del cursor `#mouse` (estilos comentados + listener `mousemove` + `div`).

## Secciones

- **`Section`**: el `padding: 6rem` asfixiaba el contenido en pantallas chicas → se reduce por tramos (`4rem/2rem` en tablet, `3rem/1.25rem` en móvil). Afecta a todas las secciones.
- **`Contact`** (no tenía ninguna media query): panel a todo el ancho, inputs y tarjetas de contacto apiladas en móvil, y se libera la altura fija de `1000px`.
- **`About`**: se libera la altura fija de `800px` al apilar en columna; corregido un bug donde `grid-template-columns` se aplicaba a un contenedor `flex` (no-op) → `flex-direction`.
- **`Home`**: `height: 100vh → 100dvh`, `width: 100vw → 100%` (evita scroll horizontal), menos `padding` y ancho ajustado en móvil.
- **`ExperienceDetail`**: el diálogo usa `100dvh` en móvil (antes `100vh`).
- **`NavBar` / `Projects` / `Technologies` / `ButtonGlitch` / `ExperienceCard` / `Terminal`**: breakpoints migrados a la convención.

## Notas / pendientes opcionales

- **`cv-lab`**: en móvil apila InputPanel arriba y Preview abajo — funcional y sin overflow. Convertirlo a pestañas Editar/Previsualizar quedaría como mejora de UX opcional (cambio de JS mayor, no incluido).
- **Hero 3D (`ShipHero`)**: el canvas ya se dimensiona de forma responsive; degradarlo a póster estático en móvil (optimización de rendimiento) requiere un asset de imagen y queda como follow-up.
- El componente `MobileWarning.astro` queda en el repo pero sin uso, por si se quisiera reactivar el gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kc71oKJ7ayw9PcpAKbLAPa)_